### PR TITLE
Change "n_cores" arg to "cores" & allow to be output of makeCluster

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: qtl2geno
-Version: 0.3-5
-Date: 2015-09-15
+Version: 0.3-6
+Date: 2015-09-17
 Title: Treatment of Marker Genotypes for QTL Experiments
 Description: Functions to calculate QTL genotype probabilities, impute
     QTL genotypes, and estimate genetic maps. Part of R/qtl2, a

--- a/R/sim_geno.R
+++ b/R/sim_geno.R
@@ -24,8 +24,10 @@
 #' @param map_function Character string indicating the map function to
 #' use to convert genetic distances to recombination fractions.
 #' @param quiet If \code{FALSE}, print progress messages.
-#' @param n_cores Number of CPU cores to use, for parallel calculations.
+#' @param cores Number of CPU cores to use, for parallel calculations.
 #' (If \code{0}, use \code{\link[parallel]{detectCores}}.)
+#' Alternatively, this can be links to a set of cluster sockets, as
+#' produced by \code{\link[parallel]{makeCluster}}.
 #'
 #' @return A list of three-dimensional arrays of imputed genotypes,
 #' individuals x positions x draws.  The genetic map and cross
@@ -46,7 +48,7 @@
 sim_geno <-
 function(cross, n_draws=1, step=0, off_end=0, stepwidth=c("fixed", "max"), pseudomarker_map,
          error_prob=1e-4, map_function=c("haldane", "kosambi", "c-f", "morgan"),
-         quiet=TRUE, n_cores=1)
+         quiet=TRUE, cores=1)
 {
     # check inputs
     if(class(cross) != "cross2")
@@ -56,10 +58,17 @@ function(cross, n_draws=1, step=0, off_end=0, stepwidth=c("fixed", "max"), pseud
     map_function <- match.arg(map_function)
     stepwidth <- match.arg(stepwidth)
 
-    if(n_cores==0) n_cores <- parallel::detectCores() # if 0, detect cores
-    if(n_cores > 1) {
-        if(!quiet) message(" - Using ", n_cores, " cores.")
+    if("cluster" %in% class(cores) && "SOCKcluster" %in% class(cores)) { # cluster already set
+        cluster_ready <- TRUE
+        if(!quiet) message(" - Using ", length(cores), " cores.")
         quiet <- TRUE # no more messages
+    } else {
+        cluster_ready <- FALSE
+        if(cores==0) cores <- parallel::detectCores() # if 0, detect cores
+        if(cores > 1) {
+            if(!quiet) message(" - Using ", cores, " cores.")
+            quiet <- TRUE # no more messages
+        }
     }
 
     # construct map at which to do the calculations
@@ -103,16 +112,18 @@ function(cross, n_draws=1, step=0, off_end=0, stepwidth=c("fixed", "max"), pseud
     }
 
     chrs <- seq(along=map)
-    if(n_cores<=1) { # no parallel processing
+    if(!cluster_ready && cores<=1) { # no parallel processing
         draws <- lapply(chrs, by_chr_func)
     }
-    else if(Sys.info()[1] == "Windows") { # Windows doesn't suport mclapply
-        cl <- parallel::makeCluster(n_cores)
-        on.exit(parallel::stopCluster(cl))
-        draws <- parallel::clusterApply(cl, chrs, by_chr_func)
+    else if(cluster_ready || Sys.info()[1] == "Windows") { # Windows doesn't suport mclapply
+        if(!cluster_ready) {
+            cores <- parallel::makeCluster(cores)
+            on.exit(parallel::stopCluster(cores))
+        }
+        draws <- parallel::clusterApply(cores, chrs, by_chr_func)
     }
     else {
-        draws <- parallel::mclapply(chrs, by_chr_func, mc.cores=n_cores)
+        draws <- parallel::mclapply(chrs, by_chr_func, mc.cores=cores)
     }
 
     names(draws) <- names(cross$gmap)

--- a/man/calc_genetic_sim.Rd
+++ b/man/calc_genetic_sim.Rd
@@ -5,7 +5,7 @@
 \title{Calculate genetic similarity among individuals}
 \usage{
 calc_genetic_sim(probs, use_grid_only = TRUE, omit_x = TRUE,
-  use_allele_probs = TRUE, quiet = TRUE, n_cores = 1)
+  use_allele_probs = TRUE, quiet = TRUE, cores = 1)
 }
 \arguments{
 \item{probs}{List of three-dimensional arrays of probabilities, as
@@ -24,8 +24,10 @@ probabilities.}
 
 \item{quiet}{IF \code{FALSE}, print progress messages.}
 
-\item{n_cores}{Number of CPU cores to use, for parallel calculations.
-(If \code{0}, use \code{\link[parallel]{detectCores}}.)}
+\item{cores}{Number of CPU cores to use, for parallel calculations.
+(If \code{0}, use \code{\link[parallel]{detectCores}}.)
+Alternatively, this can be links to a set of cluster sockets, as
+produced by \code{\link[parallel]{makeCluster}}.}
 }
 \value{
 A matrix of proportion of matching alleles.

--- a/man/calc_genoprob.Rd
+++ b/man/calc_genoprob.Rd
@@ -6,7 +6,7 @@
 \usage{
 calc_genoprob(cross, step = 0, off_end = 0, stepwidth = c("fixed", "max"),
   pseudomarker_map, error_prob = 0.0001, map_function = c("haldane",
-  "kosambi", "c-f", "morgan"), quiet = TRUE, n_cores = 1)
+  "kosambi", "c-f", "morgan"), quiet = TRUE, cores = 1)
 }
 \arguments{
 \item{cross}{Object of class \code{"cross2"}. For details, see the
@@ -34,8 +34,10 @@ use to convert genetic distances to recombination fractions.}
 
 \item{quiet}{If \code{FALSE}, print progress messages.}
 
-\item{n_cores}{Number of CPU cores to use, for parallel calculations.
-(If \code{0}, use \code{\link[parallel]{detectCores}}.)}
+\item{cores}{Number of CPU cores to use, for parallel calculations.
+(If \code{0}, use \code{\link[parallel]{detectCores}}.)
+Alternatively, this can be links to a set of cluster sockets, as
+produced by \code{\link[parallel]{makeCluster}}.}
 }
 \value{
 A list of three-dimensional arrays of probabilities,

--- a/man/est_map.Rd
+++ b/man/est_map.Rd
@@ -6,7 +6,7 @@
 \usage{
 est_map(cross, error_prob = 0.0001, map_function = c("haldane", "kosambi",
   "c-f", "morgan"), maxit = 10000, tol = 0.000001, quiet = TRUE,
-  n_cores = 1)
+  cores = 1)
 }
 \arguments{
 \item{cross}{Object of class \code{"cross2"}. For details, see the
@@ -23,8 +23,10 @@ use to convert genetic distances to recombination fractions.}
 
 \item{quiet}{If \code{FALSE}, print progress messages.}
 
-\item{n_cores}{Number of CPU cores to use, for parallel calculations.
-(If \code{0}, use \code{\link[parallel]{detectCores}}.)}
+\item{cores}{Number of CPU cores to use, for parallel calculations.
+(If \code{0}, use \code{\link[parallel]{detectCores}}.)
+Alternatively, this can be links to a set of cluster sockets, as
+produced by \code{\link[parallel]{makeCluster}}.}
 }
 \value{
 A list of numeric vectors, with the estimated marker
@@ -41,7 +43,7 @@ but a map function (by default, Haldane's) is used to derive the genetic distanc
 }
 \examples{
 grav2 <- read_cross2(system.file("extdata", "grav2.zip", package="qtl2geno"))
-gmap <- est_map(grav2, error_prob=0.002, n_cores=1)
+gmap <- est_map(grav2, error_prob=0.002)
 }
 \keyword{utilities}
 

--- a/man/genoprob_to_alleleprob.Rd
+++ b/man/genoprob_to_alleleprob.Rd
@@ -4,7 +4,7 @@
 \alias{genoprob_to_alleleprob}
 \title{Convert genotype probabilities to allele probabilities}
 \usage{
-genoprob_to_alleleprob(probs, quiet = TRUE, n_cores = 1)
+genoprob_to_alleleprob(probs, quiet = TRUE, cores = 1)
 }
 \arguments{
 \item{probs}{List of three-dimensional arrays of probabilities, as
@@ -12,8 +12,10 @@ calculated from \code{\link{calc_genoprob}}.}
 
 \item{quiet}{IF \code{FALSE}, print progress messages.}
 
-\item{n_cores}{Number of CPU cores to use, for parallel calculations.
-(If \code{0}, use \code{\link[parallel]{detectCores}}.)}
+\item{cores}{Number of CPU cores to use, for parallel calculations.
+(If \code{0}, use \code{\link[parallel]{detectCores}}.)
+Alternatively, this can be links to a set of cluster sockets, as
+produced by \code{\link[parallel]{makeCluster}}.}
 }
 \value{
 List of three-dimensional arrays of probabilities,

--- a/man/sim_geno.Rd
+++ b/man/sim_geno.Rd
@@ -7,7 +7,7 @@
 sim_geno(cross, n_draws = 1, step = 0, off_end = 0,
   stepwidth = c("fixed", "max"), pseudomarker_map, error_prob = 0.0001,
   map_function = c("haldane", "kosambi", "c-f", "morgan"), quiet = TRUE,
-  n_cores = 1)
+  cores = 1)
 }
 \arguments{
 \item{cross}{Object of class \code{"cross2"}. For details, see the
@@ -37,8 +37,10 @@ use to convert genetic distances to recombination fractions.}
 
 \item{quiet}{If \code{FALSE}, print progress messages.}
 
-\item{n_cores}{Number of CPU cores to use, for parallel calculations.
-(If \code{0}, use \code{\link[parallel]{detectCores}}.)}
+\item{cores}{Number of CPU cores to use, for parallel calculations.
+(If \code{0}, use \code{\link[parallel]{detectCores}}.)
+Alternatively, this can be links to a set of cluster sockets, as
+produced by \code{\link[parallel]{makeCluster}}.}
 }
 \value{
 A list of three-dimensional arrays of imputed genotypes,


### PR DESCRIPTION
- In calc_genetic_sim, calc_genoprob, est_map, genoprob_to_alleleprob,
  and sim_geno
- "cores" argument can be an integer specifying the number of cores (or
  0, for use of detectCores), as before, but can now also be the output
  of makeCluster(), if a "cluster" has already been created.
- I'm hoping this might allow parallel analysis across multiple devices
  (and not just the multiple cores within one machine)
