### PR TITLE
Don't let inter-marker rec fracs get too small

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: qtl2geno
-Version: 0.3-9
-Date: 2015-09-18
+Version: 0.3-10
+Date: 2015-09-19
 Title: Treatment of Marker Genotypes for QTL Experiments
 Description: Functions to calculate QTL genotype probabilities, impute
     QTL genotypes, and estimate genetic maps. Part of R/qtl2, a

--- a/R/calc_genoprob.R
+++ b/R/calc_genoprob.R
@@ -94,7 +94,7 @@ function(cross, step=0, off_end=0, stepwidth=c("fixed", "max"), pseudomarker_map
                                 pseudomarker_map, tol)
 
     probs <- vector("list", length(map))
-    rf <- lapply(map, function(m) mf(diff(m), map_function))
+    rf <- map2rf(map, map_function)
 
     # deal with missing information
     n.ind <- nrow(cross$geno[[1]])
@@ -149,17 +149,4 @@ function(cross, step=0, off_end=0, stepwidth=c("fixed", "max"), pseudomarker_map
     class(probs) <- c("calc_genoprob", "list")
 
     probs
-}
-
-# create empty set of matrices for founder genotype data
-create_empty_founder_geno <-
-function(geno)
-{
-    result <- vector("list", length(geno))
-    names(result) <- names(geno)
-    for(i in seq(along=geno)) {
-        result[[i]] <- matrix(0L, nrow=0, ncol=ncol(geno[[i]]))
-        colnames(result[[i]]) <- colnames(geno[[i]])
-    }
-    result
 }

--- a/R/est_map.R
+++ b/R/est_map.R
@@ -84,7 +84,7 @@ function(cross, error_prob=1e-4,
         ntyped <- rowSums(geno>0)
         keep <- (ntyped >= 2)
 
-        rf_start <- mf(diff(gmap), map_function) # positions to inter-marker rec frac
+        rf_start <- map2rf(gmap) # positions to inter-marker rec frac
         rf <- .est_map(cross$crosstype, t(cross$geno[[chr]][keep,,drop=FALSE]),
                        founder_geno[[chr]], is_x_chr[chr], is_female[keep],
                        cross_info[,keep,drop=FALSE],

--- a/R/hmm_util.R
+++ b/R/hmm_util.R
@@ -15,7 +15,7 @@ function(geno)
 
 # convert map to rf
 map2rf <-
-    function(map, map_function=c("haldane", "kosambi", "c-f", "morgan"), tol=1e-8)
+    function(map, map_function=c("haldane", "kosambi", "c-f", "morgan"), tol=1e-12)
 {
     map_function <- match.arg(map_function)
 

--- a/R/hmm_util.R
+++ b/R/hmm_util.R
@@ -1,0 +1,30 @@
+# various internal utility functions
+
+# create empty set of matrices for founder genotype data
+create_empty_founder_geno <-
+function(geno)
+{
+    result <- vector("list", length(geno))
+    names(result) <- names(geno)
+    for(i in seq(along=geno)) {
+        result[[i]] <- matrix(0L, nrow=0, ncol=ncol(geno[[i]]))
+        colnames(result[[i]]) <- colnames(geno[[i]])
+    }
+    result
+}
+
+# convert map to rf
+map2rf <-
+    function(map, map_function=c("haldane", "kosambi", "c-f", "morgan"), tol=1e-8)
+{
+    map_function <- match.arg(map_function)
+
+    # if list, use lapply and call this same function for each chromosome
+    if(is.list(map))
+        return(lapply(map, map2rf, map_function, tol))
+
+    rf <- mf(diff(map), map_function)
+    rf[rf < tol] <- tol # don't let values be too small
+
+    rf
+}

--- a/R/read_cross2.R
+++ b/R/read_cross2.R
@@ -198,13 +198,14 @@ function(geno, genotypes)
     }
 
     # re-code
-    for(g in gnames)
-        newgeno[!is.na(geno) & geno==g] <- genotypes[[g]]
+    for(g in gnames) {
+        if(g != genotypes[[g]]) # if g==genotypes[[g]], don't need to switch
+            newgeno[!is.na(geno) & geno==g] <- genotypes[[g]]
+    }
 
     # turn missing values to 0s
     newgeno[is.na(newgeno)] <- "0"
 
-    #
     storage.mode(newgeno) <- "integer"
 
     newgeno

--- a/R/sim_geno.R
+++ b/R/sim_geno.R
@@ -81,7 +81,7 @@ function(cross, n_draws=1, step=0, off_end=0, stepwidth=c("fixed", "max"), pseud
                                 pseudomarker_map, tol)
 
     probs <- vector("list", length(map))
-    rf <- lapply(map, function(m) mf(diff(m), map_function))
+    rf <- map2rf(map, map_function)
 
     # deal with missing information
     n.ind <- nrow(cross$geno[[1]])


### PR DESCRIPTION
calc_genoprob was giving all NAs with real DO data, because many recombination fractions were exactly 0.

Now taking `rf[rf < tol] <- tol` for `tol = 1e-12`.
