### PR TITLE
In convert2cross2, always include a column for cross_info

### DIFF
--- a/R/convert2cross2.R
+++ b/R/convert2cross2.R
@@ -48,7 +48,7 @@ function(cross)
     names(result$is_female) <- ids
 
     if(is.null(sexpgm$pgm))
-        result$cross_info <- matrix(0L, ncol=0, nrow=n.ind)
+        result$cross_info <- matrix(0L, ncol=1, nrow=n.ind) # if missing, assume they're all 0's
     else result$cross_info <- matrix(sexpgm$pgm)
     rownames(result$cross_info) <- ids
 

--- a/tests/testthat/test-convert2cross2.R
+++ b/tests/testthat/test-convert2cross2.R
@@ -43,7 +43,7 @@ test_that("convert2cross2 works appropriately for hyper data", {
     expect_equal(hyper2$is_female, is_female)
 
     # cross_info
-    cross_info <- matrix(0L, ncol=0, nrow=nind(hyper))
+    cross_info <- matrix(0L, ncol=1, nrow=nind(hyper))
     rownames(cross_info) <- ids
     expect_equal(hyper2$cross_info, cross_info)
 


### PR DESCRIPTION
(even if it's not needed, include a column with a bunch of 0's)
