### PR TITLE
Fix seg fault in est_map in case of 2 markers (in intercross)

### DIFF
--- a/src/hmm_estmap.cpp
+++ b/src/hmm_estmap.cpp
@@ -90,7 +90,7 @@ NumericVector est_map(const String& crosstype,
 
             for(int pos=0; pos<n_rf; pos++) {
                 // calculate gamma = log Pr(v1, v2, O)
-                NumericMatrix gamma(alpha.rows(), alpha.cols());
+                NumericMatrix gamma(n_poss_gen, n_poss_gen);
                 double sum_gamma=0.0;
                 bool sum_gamma_undef = true;
                 for(int ir=0; ir<n_poss_gen; ir++) {

--- a/tests/testthat/test-estmap.R
+++ b/tests/testthat/test-estmap.R
@@ -148,3 +148,34 @@ test_that("est_map for haploids matches R/qtl", {
                  lapply(newmap2, attr, "loglik"))
 
 })
+
+test_that("est_map works in case of 2 markers", {
+    data(hyper)
+    hyper <- pull.markers(hyper, markers=markernames(hyper, chr=6)[2:3])
+    hyper <- shiftmap(hyper)
+
+    newmap <- est.map(hyper, err=0.002, tol=1e-8)
+    newmap <- lapply(newmap, unclass)
+
+    hyper2 <- convert2cross2(hyper)
+    newmap2 <- est_map(hyper2, err=0.002, tol=1e-8)
+
+    expect_equivalent(newmap, newmap2)
+    expect_equal(lapply(newmap, attr, "loglik"),
+                 lapply(newmap2, attr, "loglik"))
+})
+
+test_that("est_map works in case of 2 markers in intercross", {
+
+    data(fake.f2)
+    fake.f2 <- fake.f2[18,]
+    newmap <- est.map(fake.f2, err=0.01, tol=1e-8)
+    newmap <- lapply(newmap, unclass)
+
+    fake.f2.2 <- convert2cross2(fake.f2)
+    newmap2 <- est_map(fake.f2.2, err=0.01, tol=1e-8)
+
+    expect_equivalent(newmap, newmap2)
+    expect_equal(lapply(newmap, attr, "loglik"),
+                 lapply(newmap2, attr, "loglik"))
+})


### PR DESCRIPTION
Fixes issue #35. Wrong dimensions for an object in C++.
