### PR TITLE
Dealing with alignment of sex, cross, and genotypes

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: qtl2geno
-Version: 0.3-15
-Date: 2015-10-06
+Version: 0.3-16
+Date: 2015-10-08
 Title: Treatment of Marker Genotypes for QTL Experiments
 Description: Functions to calculate QTL genotype probabilities, impute
     QTL genotypes, and estimate genetic maps. Part of R/qtl2, a

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: qtl2geno
-Version: 0.3-14
-Date: 2015-09-30
+Version: 0.3-15
+Date: 2015-10-06
 Title: Treatment of Marker Genotypes for QTL Experiments
 Description: Functions to calculate QTL genotype probabilities, impute
     QTL genotypes, and estimate genetic maps. Part of R/qtl2, a

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: qtl2geno
-Version: 0.3-13
-Date: 2015-09-28
+Version: 0.3-14
+Date: 2015-09-30
 Title: Treatment of Marker Genotypes for QTL Experiments
 Description: Functions to calculate QTL genotype probabilities, impute
     QTL genotypes, and estimate genetic maps. Part of R/qtl2, a

--- a/R/calc_genoprob.R
+++ b/R/calc_genoprob.R
@@ -99,11 +99,7 @@ function(cross, step=0, off_end=0, stepwidth=c("fixed", "max"), pseudomarker_map
     # deal with missing information
     n.ind <- nrow(cross$geno[[1]])
     chrnames <- names(cross$geno)
-    cross_info <- handle_null_crossinfo(cross$cross_info, n.ind)
-    is_female <- handle_null_isfemale(cross$is_female, n.ind)
     is_x_chr <- handle_null_isxchr(cross$is_x_chr, chrnames)
-
-    cross_info <- t(cross$cross_info)
 
     founder_geno <- cross$founder_geno
     if(is.null(founder_geno))
@@ -112,13 +108,18 @@ function(cross, step=0, off_end=0, stepwidth=c("fixed", "max"), pseudomarker_map
     by_chr_func <- function(chr) {
         if(!quiet) cat("Chr ", names(cross$geno)[chr], "\n")
 
-        pr <- .calc_genoprob(cross$crosstype, t(cross$geno[[chr]]),
-                             founder_geno[[chr]], cross$is_x_chr[chr], is_female,
-                             cross_info, rf[[chr]], attr(map[[chr]], "index"),
+        # align genotypes, is_female, and cross_info
+        gfc <- align_geno_sex_cross(cross$geno[[chr]],
+                                    cross$is_female,
+                                    cross$cross_info)
+
+        pr <- .calc_genoprob(cross$crosstype, t(gfc$geno),
+                             founder_geno[[chr]], cross$is_x_chr[chr], gfc$is_female,
+                             t(gfc$cross_info), rf[[chr]], attr(map[[chr]], "index"),
                              error_prob)
         pr <- aperm(pr, c(2,1,3))
 
-        dimnames(pr) <- list(rownames(cross$geno[[chr]]),
+        dimnames(pr) <- list(rownames(gfc$geno),
                              NULL, # FIX ME: need genotype names in here
                              names(map[[chr]]))
         pr

--- a/R/calc_genoprob.R
+++ b/R/calc_genoprob.R
@@ -97,9 +97,11 @@ function(cross, step=0, off_end=0, stepwidth=c("fixed", "max"), pseudomarker_map
     rf <- map2rf(map, map_function)
 
     # deal with missing information
-    n.ind <- nrow(cross$geno[[1]])
+    ind <- rownames(cross$geno[[1]])
     chrnames <- names(cross$geno)
     is_x_chr <- handle_null_isxchr(cross$is_x_chr, chrnames)
+    cross$is_female <- handle_null_isfemale(cross$is_female, ind)
+    cross$cross_info <- handle_null_isfemale(cross$cross_info, ind)
 
     founder_geno <- cross$founder_geno
     if(is.null(founder_geno))
@@ -108,18 +110,13 @@ function(cross, step=0, off_end=0, stepwidth=c("fixed", "max"), pseudomarker_map
     by_chr_func <- function(chr) {
         if(!quiet) cat("Chr ", names(cross$geno)[chr], "\n")
 
-        # align genotypes, is_female, and cross_info
-        gfc <- align_geno_sex_cross(cross$geno[[chr]],
-                                    cross$is_female,
-                                    cross$cross_info)
-
-        pr <- .calc_genoprob(cross$crosstype, t(gfc$geno),
-                             founder_geno[[chr]], cross$is_x_chr[chr], gfc$is_female,
-                             t(gfc$cross_info), rf[[chr]], attr(map[[chr]], "index"),
+        pr <- .calc_genoprob(cross$crosstype, t(cross$geno[[chr]]),
+                             founder_geno[[chr]], cross$is_x_chr[chr], cross$is_female,
+                             t(cross$cross_info), rf[[chr]], attr(map[[chr]], "index"),
                              error_prob)
         pr <- aperm(pr, c(2,1,3))
 
-        dimnames(pr) <- list(rownames(gfc$geno),
+        dimnames(pr) <- list(rownames(cross$geno[[chr]]),
                              NULL, # FIX ME: need genotype names in here
                              names(map[[chr]]))
         pr

--- a/R/check_cross.R
+++ b/R/check_cross.R
@@ -124,6 +124,17 @@ function(cross2)
         names(is_x_chr) <- names(geno)
         cross2$is_x_chr <- is_x_chr
     }
+    else {
+        chr <- names(cross2$geno)
+        # double-check X chr in case that one of the chromosomes is called "X" or "x"
+        if(any(chr=="X" | chr=="x")) {
+          if(all(is_x_chr[chr=="X" | chr=="x"]) &&
+             !any(is_x_chr[chr!="X" & chr!="x"]))
+              warning("Suspicious indication of X chromosome:\n",
+                      "    autosomes: ", paste(chr[!is_x_chr], collapse=" "), "\n",
+                      "    X chr: ", paste(chr[is_x_chr], collapse=" "))
+      }
+    }
 
     if(!check_handle_x_chr(crosstype, any(is_x_chr))) {
         result <- FALSE

--- a/R/check_cross.R
+++ b/R/check_cross.R
@@ -28,11 +28,11 @@ function(cross2)
     dimnames(result) <- list(rownames(cross2$geno[[1]]),
                              names(cross2$geno))
 
-    n.ind <- nrow(cross2$geno[[1]])
+    ind <- rownames(cross2$geno[[1]])
 
     # handle case of missing cross_info or is_female
-    cross_info <- handle_null_crossinfo(cross2$cross_info, n.ind)
-    is_female <- handle_null_isfemale(cross2$is_female, n.ind)
+    cross_info <- handle_null_crossinfo(cross2$cross_info, ind)
+    is_female <- handle_null_isfemale(cross2$is_female, ind)
     is_x_chr <- handle_null_isxchr(cross2$is_x_chr, names(cross2$geno))
 
     cross_info <- t(cross_info)
@@ -399,19 +399,23 @@ function(cross2)
 }
 
 handle_null_crossinfo <-
-    function(crossinfo, n_ind)
+    function(crossinfo, ids)
 {
+    n_ind <- length(ids)
     if(is.null(crossinfo)) {
         crossinfo <- matrix(0L, nrow=n_ind, ncol=0)
+        rownames(crossinfo) <- ids
     }
     crossinfo
 }
 
 handle_null_isfemale <-
-    function(isfemale, n_ind)
+    function(isfemale, ids)
 {
+    n_ind <- length(ids)
     if(is.null(isfemale)) {
         isfemale <- rep(FALSE, n_ind)
+        names(isfemale) <- ids
     }
     isfemale
 }

--- a/R/check_cross.R
+++ b/R/check_cross.R
@@ -128,8 +128,8 @@ function(cross2)
         chr <- names(cross2$geno)
         # double-check X chr in case that one of the chromosomes is called "X" or "x"
         if(any(chr=="X" | chr=="x")) {
-          if(all(is_x_chr[chr=="X" | chr=="x"]) &&
-             !any(is_x_chr[chr!="X" & chr!="x"]))
+          if(!all(is_x_chr[chr=="X" | chr=="x"]) ||
+             any(is_x_chr[chr!="X" & chr!="x"]))
               warning("Suspicious indication of X chromosome:\n",
                       "    autosomes: ", paste(chr[!is_x_chr], collapse=" "), "\n",
                       "    X chr: ", paste(chr[is_x_chr], collapse=" "))

--- a/R/convert2cross2.R
+++ b/R/convert2cross2.R
@@ -89,5 +89,8 @@ function(cross)
     }
 
     class(result) <- "cross2"
+
+    check_cross2(result) # double-check
+
     result
 }

--- a/R/est_map.R
+++ b/R/est_map.R
@@ -46,11 +46,7 @@ function(cross, error_prob=1e-4,
     # deal with missing information
     n.ind <- nrow(cross$geno[[1]])
     chrnames <- names(cross$geno)
-    cross_info <- handle_null_crossinfo(cross$cross_info, n.ind)
-    is_female <- handle_null_isfemale(cross$is_female, n.ind)
     is_x_chr <- handle_null_isxchr(cross$is_x_chr, chrnames)
-
-    cross_info <- t(cross_info)
 
     map <- vector("list", length(cross$gmap))
 
@@ -82,12 +78,14 @@ function(cross, error_prob=1e-4,
         # omit individuals with < 2 genotypes
         geno <- cross$geno[[chr]]
         ntyped <- rowSums(geno>0)
-        keep <- (ntyped >= 2)
+        geno <- geno[ntyped >= 2,,drop=FALSE]
+
+        gfc <- align_geno_sex_cross(geno, cross$is_female, cross$cross_info)
 
         rf_start <- map2rf(gmap) # positions to inter-marker rec frac
-        rf <- .est_map(cross$crosstype, t(cross$geno[[chr]][keep,,drop=FALSE]),
-                       founder_geno[[chr]], is_x_chr[chr], is_female[keep],
-                       cross_info[,keep,drop=FALSE],
+        rf <- .est_map(cross$crosstype, t(gfc$geno),
+                       founder_geno[[chr]], is_x_chr[chr], gfc$is_female,
+                       t(gfc$cross_info),
                        rf_start,
                        error_prob, maxit, tol, !quiet)
 

--- a/R/est_map.R
+++ b/R/est_map.R
@@ -44,9 +44,11 @@ function(cross, error_prob=1e-4,
     if(tol <= 0) stop("tol must be > 0")
 
     # deal with missing information
-    n.ind <- nrow(cross$geno[[1]])
+    ind <- rownames(cross$geno[[1]])
     chrnames <- names(cross$geno)
     is_x_chr <- handle_null_isxchr(cross$is_x_chr, chrnames)
+    cross$is_female <- handle_null_isfemale(cross$is_female, ind)
+    cross$cross_info <- handle_null_isfemale(cross$cross_info, ind)
 
     map <- vector("list", length(cross$gmap))
 
@@ -78,14 +80,15 @@ function(cross, error_prob=1e-4,
         # omit individuals with < 2 genotypes
         geno <- cross$geno[[chr]]
         ntyped <- rowSums(geno>0)
-        geno <- geno[ntyped >= 2,,drop=FALSE]
-
-        gfc <- align_geno_sex_cross(geno, cross$is_female, cross$cross_info)
+        keep <- ntyped >= 2
+        geno <- t(geno[keep,,drop=FALSE])
+        is_female <- cross$is_female[keep]
+        cross_info <- t(cross$cross_info[keep,,drop=FALSE])
 
         rf_start <- map2rf(gmap) # positions to inter-marker rec frac
-        rf <- .est_map(cross$crosstype, t(gfc$geno),
-                       founder_geno[[chr]], is_x_chr[chr], gfc$is_female,
-                       t(gfc$cross_info),
+        rf <- .est_map(cross$crosstype, geno,
+                       founder_geno[[chr]], is_x_chr[chr], is_female,
+                       cross_info,
                        rf_start,
                        error_prob, maxit, tol, !quiet)
 

--- a/R/find_common_ids.R
+++ b/R/find_common_ids.R
@@ -1,11 +1,11 @@
-# find common ids
+# match ids
 #
 # takes two vectors of character strings
 # returns a list with
 #   first,second = indexes in both vectors, to make them aligned
 #   firstonly = indexes in first vector that are not in the second
 #   secondonly = indexes in second vector that are not in the first
-find_common_ids <-
+match_ids <-
     function(x,y)
 {
     mxy <- match(x, y)
@@ -26,4 +26,31 @@ find_common_ids <-
         names(result$secondonly) <- y[result$secondonly]
 
     result
+}
+
+# find common ids across a set of vectors of character string
+# return value: ids that are present in *all* of the inputs
+find_common_ids <-
+    function(...)
+{
+    inp <- list(...)
+    n_inp <- length(inp)
+
+    if(n_inp==0)
+        stop("No input")
+
+    if(n_inp==1) {
+        if(length(inp[[1]])==0) return(character(0))
+        return(inp[[1]])
+    }
+
+    reduced <- inp[[1]]
+    for(i in 2:n_inp) {
+        m <- match_ids(reduced, inp[[i]])
+        reduced <- reduced[m$first]
+    }
+
+    if(length(reduced)==0) return(character(0))
+
+    reduced
 }

--- a/R/find_common_ids.R
+++ b/R/find_common_ids.R
@@ -54,3 +54,19 @@ find_common_ids <-
 
     reduced
 }
+
+# align genotypes, is_female and cross_info
+# (because we'll do this alot)
+align_geno_sex_cross <-
+    function(geno, is_female, cross_info)
+{
+    ind <- rownames(geno)
+    is_female <- handle_null_isfemale(is_female, ind)
+    cross_info <- handle_null_crossinfo(cross_info, ind)
+
+    keep <- find_common_ids(rownames(geno), names(is_female), rownames(cross_info))
+
+    list(geno=geno[keep,,drop=FALSE],
+         is_female=is_female[keep],
+         cross_info=cross_info[keep,,drop=FALSE])
+}

--- a/R/find_common_ids.R
+++ b/R/find_common_ids.R
@@ -1,0 +1,29 @@
+# find common ids
+#
+# takes two vectors of character strings
+# returns a list with
+#   first,second = indexes in both vectors, to make them aligned
+#   firstonly = indexes in first vector that are not in the second
+#   secondonly = indexes in second vector that are not in the first
+find_common_ids <-
+    function(x,y)
+{
+    mxy <- match(x, y)
+    myx <- match(y, x)
+
+    result <- list(first=which(!is.na(mxy)),
+                   second=mxy[!is.na(mxy)],
+                   firstonly=which(is.na(mxy)),
+                   secondonly=which(is.na(myx)))
+
+    if(length(result$first) > 0)
+        names(result$first) <- x[result$first]
+    if(length(result$firstonly) > 0)
+        names(result$firstonly) <- x[result$firstonly]
+    if(length(result$second) > 0)
+        names(result$second) <- y[result$second]
+    if(length(result$secondonly) > 0)
+        names(result$secondonly) <- y[result$secondonly]
+
+    result
+}

--- a/R/find_common_ids.R
+++ b/R/find_common_ids.R
@@ -60,11 +60,28 @@ find_common_ids <-
 align_geno_sex_cross <-
     function(geno, is_female, cross_info)
 {
+    if(is.list(geno)) {
+        for(i in seq(along=geno)) {
+            tmp <- align_geno_sex_cross(geno[[i]],
+                                        is_female,
+                                        cross_info)
+            is_female <- tmp$is_female
+            cross_info <- tmp$cross_info
+            geno[[i]] <- tmp$geno
+        }
+        return(list(geno=geno, is_female=is_female, cross_info=cross_info))
+    }
+
     ind <- rownames(geno)
     is_female <- handle_null_isfemale(is_female, ind)
     cross_info <- handle_null_crossinfo(cross_info, ind)
 
     keep <- find_common_ids(rownames(geno), names(is_female), rownames(cross_info))
+
+    if(length(keep) < length(ind))
+        warning("Omitting genotypes for ",
+                length(ind)-length(keep),
+                " individuals with no sex/cross info.")
 
     list(geno=geno[keep,,drop=FALSE],
          is_female=is_female[keep],

--- a/R/read_cross2.R
+++ b/R/read_cross2.R
@@ -172,6 +172,17 @@ function(file, quiet=TRUE)
         output$alleles <- control$alleles
 
     class(output) <- "cross2"
+
+    # force genotypes, is_female, and cross_info to be aligned
+    gfc <- align_geno_sex_cross(output$geno,
+                                output$is_female,
+                                output$cross_info)
+    output$geno <- gfc$geno
+    output$is_female <- gfc$is_female
+    output$cross_info <- gfc$cross_info
+
+    summary(output) # run all the checks
+
     output
 }
 

--- a/R/read_cross2.R
+++ b/R/read_cross2.R
@@ -181,7 +181,7 @@ function(file, quiet=TRUE)
     output$is_female <- gfc$is_female
     output$cross_info <- gfc$cross_info
 
-    summary(output) # run all the checks
+    check_cross2(output) # run all the checks
 
     output
 }

--- a/R/sim_geno.R
+++ b/R/sim_geno.R
@@ -86,11 +86,7 @@ function(cross, n_draws=1, step=0, off_end=0, stepwidth=c("fixed", "max"), pseud
     # deal with missing information
     n.ind <- nrow(cross$geno[[1]])
     chrnames <- names(cross$geno)
-    cross_info <- handle_null_crossinfo(cross$cross_info, n.ind)
-    is_female <- handle_null_isfemale(cross$is_female, n.ind)
     is_x_chr <- handle_null_isxchr(cross$is_x_chr, chrnames)
-
-    cross_info <- t(cross$cross_info)
 
     founder_geno <- cross$founder_geno
     if(is.null(founder_geno))
@@ -99,13 +95,16 @@ function(cross, n_draws=1, step=0, off_end=0, stepwidth=c("fixed", "max"), pseud
     by_chr_func <- function(chr) {
         if(!quiet) cat("Chr ", names(cross$geno)[chr], "\n")
 
-        dr <- .sim_geno(cross$crosstype, t(cross$geno[[chr]]),
-                        founder_geno[[chr]], cross$is_x_chr[chr], is_female,
-                        cross_info, rf[[chr]], attr(map[[chr]], "index"),
+        gfc <- align_geno_sex_cross(cross$geno[[chr]],
+                                    cross$is_female, cross$cross_info)
+
+        dr <- .sim_geno(cross$crosstype, t(gfc$geno),
+                        founder_geno[[chr]], cross$is_x_chr[chr], gfc$is_female,
+                        t(gfc$cross_info), rf[[chr]], attr(map[[chr]], "index"),
                         error_prob, n_draws)
         dr <- aperm(dr, c(3,1,2))
 
-        dimnames(dr) <- list(rownames(cross$geno[[chr]]),
+        dimnames(dr) <- list(rownames(gfc$geno),
                              names(map[[chr]]),
                              NULL)
         dr

--- a/R/sim_geno.R
+++ b/R/sim_geno.R
@@ -84,9 +84,11 @@ function(cross, n_draws=1, step=0, off_end=0, stepwidth=c("fixed", "max"), pseud
     rf <- map2rf(map, map_function)
 
     # deal with missing information
-    n.ind <- nrow(cross$geno[[1]])
+    ind <- rownames(cross$geno[[1]])
     chrnames <- names(cross$geno)
     is_x_chr <- handle_null_isxchr(cross$is_x_chr, chrnames)
+    cross$is_female <- handle_null_isfemale(cross$is_female, ind)
+    cross$cross_info <- handle_null_isfemale(cross$cross_info, ind)
 
     founder_geno <- cross$founder_geno
     if(is.null(founder_geno))
@@ -95,16 +97,13 @@ function(cross, n_draws=1, step=0, off_end=0, stepwidth=c("fixed", "max"), pseud
     by_chr_func <- function(chr) {
         if(!quiet) cat("Chr ", names(cross$geno)[chr], "\n")
 
-        gfc <- align_geno_sex_cross(cross$geno[[chr]],
-                                    cross$is_female, cross$cross_info)
-
-        dr <- .sim_geno(cross$crosstype, t(gfc$geno),
-                        founder_geno[[chr]], cross$is_x_chr[chr], gfc$is_female,
-                        t(gfc$cross_info), rf[[chr]], attr(map[[chr]], "index"),
+        dr <- .sim_geno(cross$crosstype, t(cross$geno[[chr]]),
+                        founder_geno[[chr]], cross$is_x_chr[chr], cross$is_female,
+                        t(cross$cross_info), rf[[chr]], attr(map[[chr]], "index"),
                         error_prob, n_draws)
         dr <- aperm(dr, c(3,1,2))
 
-        dimnames(dr) <- list(rownames(gfc$geno),
+        dimnames(dr) <- list(rownames(cross$geno[[chr]]),
                              names(map[[chr]]),
                              NULL)
         dr

--- a/R/subset.R
+++ b/R/subset.R
@@ -19,7 +19,7 @@
 #'
 #' @section Warning:
 #' The order of the two arguments is reversed relative to the related
-#' function in \href{http://www.rqtl.org}{R/qtl}.
+#' function in \href{http://rqtl.org}{R/qtl}.
 #'
 #' @export
 #' @keywords utilities

--- a/ReadMe.md
+++ b/ReadMe.md
@@ -5,7 +5,7 @@
 [Karl Broman](http://kbroman.org)
 
 [R/qtl2](http://kbroman.org/qtl2) (aka qtl2) is a reimplementation of
-the QTL analysis software [R/qtl](http://www.rqtl.org), to better
+the QTL analysis software [R/qtl](http://rqtl.org), to better
 handle high-dimensional data and complex cross designs. It is split
 into the [qtl2geno](https://github.com/rqtl/qtl2geno) (for calculating
 genotype probabilities, imputations, and genetic maps) and

--- a/man/subset.cross2.Rd
+++ b/man/subset.cross2.Rd
@@ -32,7 +32,7 @@ Pull out a specified set of individuals and/or chromosomes from a
 \section{Warning}{
 
 The order of the two arguments is reversed relative to the related
-function in \href{http://www.rqtl.org}{R/qtl}.
+function in \href{http://rqtl.org}{R/qtl}.
 }
 \examples{
 grav2 <- read_cross2(system.file("extdata", "grav2.zip", package="qtl2geno"))

--- a/src/hmm_forwback.cpp
+++ b/src/hmm_forwback.cpp
@@ -79,20 +79,15 @@ NumericMatrix backwardEquations(QTLCross* cross,
     // backward equations
     for(int pos = n_pos-2; pos >= 0; pos--) {
         for(int il=0; il<n_gen; il++) {
-            beta(il,pos) = beta(0,pos+1) + cross->step(poss_gen[il], poss_gen[0], rec_frac[pos],
-                                                       is_X_chr, is_female, cross_info);
-
-            if(marker_index[pos+1] >= 0)
-                beta(il,pos) += cross->emit(genotypes[marker_index[pos+1]], poss_gen[0], error_prob,
-                                            founder_geno(_, marker_index[pos+1]), is_X_chr, is_female, cross_info);
-
-            for(int ir=1; ir<n_gen; ir++) {
+            for(int ir=0; ir<n_gen; ir++) {
                 double to_add = beta(ir,pos+1) + cross->step(poss_gen[il], poss_gen[ir], rec_frac[pos],
                                                               is_X_chr, is_female, cross_info);
                 if(marker_index[pos+1] >=0)
                     to_add += cross->emit(genotypes[marker_index[pos+1]], poss_gen[ir], error_prob,
                                           founder_geno(_, marker_index[pos+1]), is_X_chr, is_female, cross_info);
-                beta(il,pos) = addlog(beta(il,pos), to_add);
+
+                if(ir==0) beta(il,pos) = to_add;
+                else beta(il,pos) = addlog(beta(il,pos), to_add);
             }
         }
     }

--- a/tests/testthat/test-basic_summaries.R
+++ b/tests/testthat/test-basic_summaries.R
@@ -1,4 +1,4 @@
-context("check cross")
+context("basic summaries")
 
 test_that("basic summaries give correct numbers for iron data", {
 

--- a/tests/testthat/test-find_common_ids.R
+++ b/tests/testthat/test-find_common_ids.R
@@ -1,6 +1,6 @@
-context("find_common_ids")
+context("find_common_ids and match_ids")
 
-test_that("find_common_ids works", {
+test_that("match_ids and find_common_ids work", {
 
     set.seed(20151006)
     first <- LETTERS[1:10]
@@ -16,12 +16,14 @@ test_that("find_common_ids works", {
     names(expected$firstonly) <- first[expected$firstonly]
     names(expected$secondonly) <- second[expected$secondonly]
 
-    expect_equal(find_common_ids(first, second), expected)
+    expect_equal(match_ids(first, second), expected)
     expect_equal(first[expected$first], second[expected$second])
+
+    expect_equal(find_common_ids(first, second), first[expected$first])
 
 })
 
-test_that("find_common_ids works with no overlap", {
+test_that("match_ids and find_common_ids work with no overlap", {
 
     set.seed(20151006)
     first <- LETTERS[1:10]
@@ -34,11 +36,14 @@ test_that("find_common_ids works with no overlap", {
     names(expected$firstonly) <- first
     names(expected$secondonly) <- second
 
-    expect_equal(find_common_ids(first, second), expected)
+    expect_equal(match_ids(first, second), expected)
+    expect_equal(first[expected$first], second[expected$second])
+
+    expect_equal(find_common_ids(first, second), first[expected$first])
 
 })
 
-test_that("find_common_ids works with null vectors", {
+test_that("match_ids and find_common_ids work with null vectors", {
 
     set.seed(20151006)
     first <- LETTERS[1:10]
@@ -50,12 +55,16 @@ test_that("find_common_ids works with null vectors", {
                      secondonly=numeric(0))
     names(expected$firstonly) <- first
 
-    expect_equal(find_common_ids(first, second), expected)
+    expect_equal(match_ids(first, second), expected)
+    expect_equal(first[expected$first], second[expected$second])
+    expect_equal(find_common_ids(first, second), first[expected$first])
 
     # switch the role of the two
     expected$secondonly <- expected$firstonly
     expected$firstonly <- numeric(0)
-    expect_equal(find_common_ids(second, first), expected)
+    expect_equal(match_ids(second, first), expected)
+    expect_equal(second[expected$first], first[expected$second])
+    expect_equal(find_common_ids(second, first), second[expected$first])
 
     # same, when second is NULL
     second <- NULL
@@ -66,18 +75,53 @@ test_that("find_common_ids works with null vectors", {
                      secondonly=numeric(0))
     names(expected$firstonly) <- first
 
-    expect_equal(find_common_ids(first, second), expected)
+    expect_equal(match_ids(first, second), expected)
+    expect_equal(find_common_ids(first, second), first[expected$first])
 
     # switch the role of the two (when second is NULL)
     expected$secondonly <- expected$firstonly
     expected$firstonly <- numeric(0)
-    expect_equal(find_common_ids(second, first), expected)
+    expect_equal(match_ids(second, first), expected)
 
     # both NULL
     expected <- list(first=numeric(0),
                      second=numeric(0),
                      firstonly=numeric(0),
                      secondonly=numeric(0))
-    expect_equal(find_common_ids(NULL, NULL), expected)
+    expect_equal(match_ids(NULL, NULL), expected)
+    expect_equal(find_common_ids(NULL, NULL), character(0))
+
+    expect_equal(match_ids(character(0), character(0)), expected)
+    expect_equal(find_common_ids(character(0), character(0)), character(0))
+
+})
+
+
+test_that("find_common_ids with <2 inputs", {
+
+    expect_error(find_common_ids())
+
+    expect_equal(find_common_ids(LETTERS[1:5]), LETTERS[1:5])
+    expect_equal(find_common_ids(NULL), character(0))
+    expect_equal(find_common_ids(character(0)), character(0))
+
+})
+
+
+test_that("find_common_ids with >2 inputs", {
+
+    set.seed(20151008)
+    first <- LETTERS[1:10]
+    second <- sample(LETTERS[3:12])
+    third <- sample(LETTERS[5:14])
+
+    expect_equal(find_common_ids(first, second, third), LETTERS[5:10])
+    expect_equal(sort(find_common_ids(second, first, third)), LETTERS[5:10])
+    expect_equal(sort(find_common_ids(third, second, first)), LETTERS[5:10])
+
+    expect_equal(find_common_ids(third, second, NULL, first), character(0))
+
+    fourth <- sample(c("H", "E", "L", "P"))
+    expect_equal(sort(find_common_ids(third, second, fourth, first)), c("E", "H"))
 
 })

--- a/tests/testthat/test-find_common_ids.R
+++ b/tests/testthat/test-find_common_ids.R
@@ -1,0 +1,83 @@
+context("find_common_ids")
+
+test_that("find_common_ids works", {
+
+    set.seed(20151006)
+    first <- LETTERS[1:10]
+    second <- sample(LETTERS[c(1:4,7:12)])
+
+    m12 <- match(first, second)
+    expected <- list(first=c(1:4, 7:10),
+                     second=m12[!is.na(m12)],
+                     firstonly=5:6,
+                     secondonly=which(second %in% LETTERS[11:12]))
+    names(expected$first) <- first[expected$first]
+    names(expected$second) <- second[expected$second]
+    names(expected$firstonly) <- first[expected$firstonly]
+    names(expected$secondonly) <- second[expected$secondonly]
+
+    expect_equal(find_common_ids(first, second), expected)
+    expect_equal(first[expected$first], second[expected$second])
+
+})
+
+test_that("find_common_ids works with no overlap", {
+
+    set.seed(20151006)
+    first <- LETTERS[1:10]
+    second <- LETTERS[11:20]
+
+    expected <- list(first=numeric(0),
+                     second=numeric(0),
+                     firstonly=1:10,
+                     secondonly=1:10)
+    names(expected$firstonly) <- first
+    names(expected$secondonly) <- second
+
+    expect_equal(find_common_ids(first, second), expected)
+
+})
+
+test_that("find_common_ids works with null vectors", {
+
+    set.seed(20151006)
+    first <- LETTERS[1:10]
+    second <- character(0)
+
+    expected <- list(first=numeric(0),
+                     second=numeric(0),
+                     firstonly=1:10,
+                     secondonly=numeric(0))
+    names(expected$firstonly) <- first
+
+    expect_equal(find_common_ids(first, second), expected)
+
+    # switch the role of the two
+    expected$secondonly <- expected$firstonly
+    expected$firstonly <- numeric(0)
+    expect_equal(find_common_ids(second, first), expected)
+
+    # same, when second is NULL
+    second <- NULL
+
+    expected <- list(first=numeric(0),
+                     second=numeric(0),
+                     firstonly=1:10,
+                     secondonly=numeric(0))
+    names(expected$firstonly) <- first
+
+    expect_equal(find_common_ids(first, second), expected)
+
+    # switch the role of the two (when second is NULL)
+    expected$secondonly <- expected$firstonly
+    expected$firstonly <- numeric(0)
+    expect_equal(find_common_ids(second, first), expected)
+
+    # both NULL
+    expected <- list(first=numeric(0),
+                     second=numeric(0),
+                     firstonly=numeric(0),
+                     secondonly=numeric(0))
+    expect_equal(find_common_ids(NULL, NULL), expected)
+
+})

--- a/vignettes/developer_guide.Rmd
+++ b/vignettes/developer_guide.Rmd
@@ -8,7 +8,7 @@ vignette: >
 ---
 
 [R/qtl2](http://kbroman.org/qtl2) (aka qtl2) is a reimplementation of the QTL analysis software
-[R/qtl](http://www.rqtl.org), to better handle high-dimensional data
+[R/qtl](http://rqtl.org), to better handle high-dimensional data
 and complex cross designs.
 
 **We have split the package into two parts,
@@ -47,7 +47,7 @@ We are also redefining the input data file formats.
 
 ## QTL data structure
 
-The basic data structure in [R/qtl](http://www.rqtl.org), the
+The basic data structure in [R/qtl](http://rqtl.org), the
 `"cross"` class, has been redesigned.
 
 A basic principle in the new design is to have the data as close as
@@ -175,7 +175,7 @@ attribute being the individual IDs.
 For many cross types, and particularly for the treatment of the X
 chromosome, we need line-level information about the nature of the
 cross. For an intercross, this is like `pgm` (for paternal
-grandmother) in [R/qtl](http://www.rqtl.org). For the Collaborative
+grandmother) in [R/qtl](http://rqtl.org). For the Collaborative
 Cross, we need the order of the founders in the set of crosses that
 led to each line. For the AIL and the Diversity Outcross, we need to
 know the number of generations of outbreeding.
@@ -375,14 +375,14 @@ straightforward, with a loop over columns.
 ## Input data file formats
 
 For simple cross types, we can use the file formats for
-[R/qtl](http://www.rqtl.org), use `qtl::read.cross` to read in the
+[R/qtl](http://rqtl.org), use `qtl::read.cross` to read in the
 data, and then use a conversion function (`convert2cross2`) to convert
 the data into the new format.
 
 For more complex crosses, we need to define a new format. I was
 persuaded by [Aaron Wolen](http://aaronwolen.com/)'s idea of a
 [&ldquo;tidy&rdquo; format](https://github.com/kbroman/qtl/pull/20)
-for [R/qtl](http://www.rqtl.org), with three separate CSV files, one
+for [R/qtl](http://rqtl.org), with three separate CSV files, one
 for phenotypes, one for genotypes, and one for the genetic map.
 
 Another important idea is from [Pjotr Prins](http://thebird.nl/)'s

--- a/vignettes/input_files.Rmd
+++ b/vignettes/input_files.Rmd
@@ -8,22 +8,22 @@ vignette: >
 ---
 
 [R/qtl2](http://kbroman.org/qtl2) (aka qtl2) is a reimplementation of the QTL analysis software
-[R/qtl](http://www.rqtl.org), to better handle high-dimensional data
+[R/qtl](http://rqtl.org), to better handle high-dimensional data
 and complex cross designs.
 
-The input data file formats for [R/qtl](http://www.rqtl.org) cannot
+The input data file formats for [R/qtl](http://rqtl.org) cannot
 handle complex crosses, and so for R/qtl2, we need to define a new
 input file format. This document describes the details.
 
 For simple cross types, we can continue to use the file formats for
-[R/qtl](http://www.rqtl.org), use `qtl::read.cross()` to read in the
+[R/qtl](http://rqtl.org), use `qtl::read.cross()` to read in the
 data, and then use a conversion function (`qtl2::convert2cross2()`) to convert
 the data into the new format.
 
 For more complex crosses, we need to define a new format. I was
 persuaded by [Aaron Wolen](http://aaronwolen.com/)'s idea of a
 [&ldquo;tidy&rdquo; format](https://github.com/kbroman/qtl/pull/20)
-for [R/qtl](http://www.rqtl.org), with three separate CSV files, one
+for [R/qtl](http://rqtl.org), with three separate CSV files, one
 for phenotypes, one for genotypes, and one for the genetic map.
 
 Another important idea is from [Pjotr Prins](http://thebird.nl/)'s

--- a/vignettes/user_guide.Rmd
+++ b/vignettes/user_guide.Rmd
@@ -8,7 +8,7 @@ vignette: >
 ---
 
 [R/qtl2](http://kbroman.org/qtl2) (aka qtl2) is a reimplementation of the QTL analysis software
-[R/qtl](http://www.rqtl.org), to better handle high-dimensional data
+[R/qtl](http://rqtl.org), to better handle high-dimensional data
 and complex cross designs.
 
 **We have split the package into two parts,
@@ -47,7 +47,7 @@ install_github(c("rqtl/qtl2geno", "rqtl/qtl2scan"))
 
 ## Data file format
 
-The input data file formats for [R/qtl](http://www.rqtl.org) cannot
+The input data file formats for [R/qtl](http://rqtl.org) cannot
 handle complex crosses, and so for R/qtl2, we have defined a new
 format for the data files. We'll describe it here briefly; for
 details, see the separate


### PR DESCRIPTION
- Requiring that these be aligned in advance when reading the data into R
- Dropping genotypes for individuals with missing sex or cross info
- Tempted to double-check in `est_map`, `calc_genoprob`, `sim_geno`, but it shouldn't be necessary.

Also added a check of `is_x_chr` looking right when there's a chromosome called `"X"` or `"x"`.
