### PR TITLE
Allow comment lines in data files

### DIFF
--- a/R/cbind_expand.R
+++ b/R/cbind_expand.R
@@ -1,0 +1,42 @@
+# cbind, matching rownames and expanding with NAs as needed
+#
+# does cbind(mat1, mat2)
+# but: - looks at rownames and makes sure they line up
+#      - if rows are in one matrix but not the other,
+#        creates row of NAs where missing
+cbind_expand <-
+    function(...)
+{
+    input <- list(...)
+    if(length(input)<2)
+        stop("Must have >= 2 input matrices")
+
+    # check IDs
+    id <- lapply(input, rownames)
+    if(any(vapply(id, is.null, TRUE)))
+        stop("All input matrices must have rownames (containing individual IDs)")
+    if(any(vapply(id, function(a) length(unique(a)) != length(a), TRUE)))
+        stop("Some input matrices have duplicate rownames")
+    uid <- unique(unlist(id))
+
+    for(i in seq(along=input)) {
+        not_in <- !(uid %in% id[[i]])
+        if(!any(not_in)) next
+        missing <- uid[not_in]
+
+        # create new rows
+        new_rows <- matrix(NA, ncol=ncol(input[[i]]), nrow=length(missing))
+        dimnames(new_rows) <- list(missing, colnames(input[[i]]))
+
+        input[[i]] <- rbind(input[[i]], new_rows)
+    }
+
+    for(i in seq(along=input)) {
+        if(i==1)
+            input[[1]] <- input[[1]][uid,,drop=FALSE]
+        else
+            input[[1]] <- cbind(input[[1]], input[[i]][uid,,drop=FALSE])
+    }
+
+    input[[1]]
+}

--- a/R/read_cross2.R
+++ b/R/read_cross2.R
@@ -168,7 +168,7 @@ function(file, quiet=TRUE)
 
     # line map (mapping of individuals to lines)
     output$linemap <- convert_linemap(control$linemap, output$covar, control$sep,
-                                      convert$comment.char, dir, quiet=quiet)
+                                      control$comment.char, dir, quiet=quiet)
 
     # alleles?
     if("alleles" %in% names(control))

--- a/R/read_cross2.R
+++ b/R/read_cross2.R
@@ -97,7 +97,7 @@ function(file, quiet=TRUE)
 
             # read file
             sheet <- read_csv(file, na.strings=control$na.strings, sep=control$sep,
-                              transpose=tr)
+                              comment.char=control$comment.char, transpose=tr)
 
             # change genotype codes and convert phenotypes to numeric matrix
             if(section=="geno" || section=="founder_geno") {
@@ -151,21 +151,24 @@ function(file, quiet=TRUE)
     }
 
     # sex
-    output$is_female <- convert_sex(control$sex, output$covar, control$sep, dir, quiet=quiet)
+    output$is_female <- convert_sex(control$sex, output$covar, control$sep,
+                                    control$comment.char, dir, quiet=quiet)
     if(is.null(output$is_female)) { # missing; assume all FALSE
         output$is_female <- rep(FALSE, nrow(output$geno[[1]]))
         names(output$is_female) <- rownames(output$geno[[1]])
     }
 
     # cross_info
-    output$cross_info <- convert_cross_info(control$cross_info, output$covar, control$sep, dir, quiet=quiet)
+    output$cross_info <- convert_cross_info(control$cross_info, output$covar, control$sep,
+                                            control$comment.char, dir, quiet=quiet)
     if(is.null(output$cross_info)) { # missing; make a 0-column matrix
         output$cross_info <- matrix(0L, ncol=0, nrow=nrow(output$geno[[1]]))
         rownames(output$cross_info) <- rownames(output$geno[[1]])
     }
 
     # line map (mapping of individuals to lines)
-    output$linemap <- convert_linemap(control$linemap, output$covar, control$sep, dir, quiet=quiet)
+    output$linemap <- convert_linemap(control$linemap, output$covar, control$sep,
+                                      convert$comment.char, dir, quiet=quiet)
 
     # alleles?
     if("alleles" %in% names(control))
@@ -332,7 +335,7 @@ function(map)
 
 # grab sex information
 convert_sex <-
-function(sex_control, covar, sep, dir, quiet=TRUE)
+function(sex_control, covar, sep, comment.char, dir, quiet=TRUE)
 {
     if(is.null(sex_control)) return(NULL)
 
@@ -343,7 +346,7 @@ function(sex_control, covar, sep, dir, quiet=TRUE)
         if(!quiet) message(" - reading sex")
         file <- file.path(dir, sex_control$file)
         stop_if_no_file(file)
-        sex <- read_csv(file, sep=sep, na.strings=NULL)
+        sex <- read_csv(file, sep=sep, na.strings=NULL, comment.char=comment.char)
     }
     else return(NULL)
 
@@ -397,7 +400,7 @@ function(codes)
 
 # grab cross_info
 convert_cross_info <-
-function(cross_info_control, covar, sep, dir, quiet=TRUE)
+function(cross_info_control, covar, sep, comment.char, dir, quiet=TRUE)
 {
     if(is.null(cross_info_control)) return(NULL)
 
@@ -411,7 +414,7 @@ function(cross_info_control, covar, sep, dir, quiet=TRUE)
 
         file <- file.path(dir, cross_info_control$file)
         stop_if_no_file(file)
-        cross_info <- read_csv(file, sep=sep)
+        cross_info <- read_csv(file, sep=sep, comment.char=comment.char)
 
         if(any(is.na(cross_info)))
             stop(sum(is.na(cross_info)), " missing values in cross_info (cross_info can't be missing.")
@@ -456,7 +459,7 @@ function(cross_info_control, covar, sep, dir, quiet=TRUE)
 
 # grab linemap information
 convert_linemap <-
-function(linemap_control, covar, sep, dir, quiet=TRUE)
+function(linemap_control, covar, sep, comment.char, dir, quiet=TRUE)
 {
     if(is.null(linemap_control)) return(NULL)
 
@@ -471,7 +474,7 @@ function(linemap_control, covar, sep, dir, quiet=TRUE)
     if("file" %in% names(linemap_control)) {
         if(!quiet) message(" - reading linemap")
         filename <- file.path(dir, linemap_control$file)
-        linemap <- read_csv(filename, sep=sep, na.strings=NULL)
+        linemap <- read_csv(filename, sep=sep, na.strings=NULL, comment.char=comment.char)
     }
     else if("covar" %in% names(linemap_control)) { # column name in the covariate data
         linemap <- covar[,linemap_control$covar, drop=FALSE]
@@ -510,13 +513,32 @@ function(filename)
 
 # read a csv file
 read_csv <-
-function(filename, sep=",", na.strings=c("NA", "-"), transpose=FALSE)
+function(filename, sep=",", na.strings=c("NA", "-"), comment.char="#", transpose=FALSE)
 {
+    # read header and extract expected number of rows and columns
+    # (number of columns includes ID column; number of rows does *not* include header row)
+    header <- read_header(filename, comment.char=comment.char)
+    expected_dim <- extract_dim_from_header(header)
+
+    # read the data
     x <- data.table::fread(filename, na.strings=na.strings, sep=sep, header=TRUE,
                            verbose=FALSE, showProgress=FALSE, data.table=FALSE,
-                           colClasses="character")
+                           colClasses="character", skip=length(header))
 
+    # check that number of rows and columns match expected from header
+    for(i in 1:2) {
+        labels <- c("rows", "columns")
+        if(!is.na(expected_dim[i])) { # nrows given
+            if(dim(x)[i] != expected_dim[i])
+                stop('In file "', filename, '", no. ', labels[i],
+                     ' (', dim(x)[i], ') != expected (', expected_dim[i], ')')
+        }
+    }
+
+    # move first column to row names
     x <- firstcol2rownames(x)
+
+    # transpose if requested
     if(transpose)
         x <- as.data.frame(t(x), stringAsFactors=FALSE)
 
@@ -536,9 +558,44 @@ function(filename)
     }
     else stop(paste('Control file', filename, 'should have extension ".yaml" or ".json"'))
 
-    # default values for sep and na.strings
+    # default values for sep, na.strings, and comment.char
     if(is.null(control$sep)) control$sep <- ","
     if(is.null(control$na.strings)) control$na.strings <- "NA"
+    if(is.null(control$comment.char)) control$comment.char <- "#"
 
     control
+}
+
+# read header lines
+read_header <-
+    function(filename, comment.char="#")
+{
+    con <- file(filename, "rt")
+    on.exit(close(con))
+    header <- NULL
+    while(length(line <- readLines(con, 1))>0) {
+        if(grepl(paste0("^", comment.char), line))
+            header <- c(header, line)
+        else break
+    }
+    header
+}
+
+# get expected dimensions from header
+# (expecting header rows like "# nrow 5201" and "# ncol 59")
+extract_dim_from_header <-
+    function(header, comment.char="#")
+{
+    result <- c(NA, NA)
+    nam <- c("nrow", "ncol")
+    for(i in seq(along=nam)) {
+        matchhead <- grepl(paste0("^", comment.char, "\\s*", nam[i], "\\s*\\d+"), header)
+        if(sum(matchhead) > 1) # more than one matches
+            stop('Multiple header lines with "', nam[i], '"')
+        if(sum(matchhead) == 0) next
+        spl <- strsplit(header[matchhead], "\\s+")[[1]]
+        result[i] <- as.numeric(spl[length(spl)])
+    }
+
+    result
 }

--- a/R/write_control_file.R
+++ b/R/write_control_file.R
@@ -54,6 +54,8 @@
 #' @param sep Character string that separates columns in the data files.
 #' @param na.strings Vector of character strings with codes to be
 #' treated as missing values.
+#' @param comment.char Character string that is used as initial
+#' character in a set of leading comment lines in the data files.
 #' @param geno_transposed If TRUE, genotype file is transposed (with markers as rows).
 #' @param founder_geno_transposed If TRUE, founder genotype file is transposed (with markers as rows).
 #' @param pheno_transposed If TRUE, phenotype file is transposed (with phenotypes as rows).
@@ -113,7 +115,7 @@ function(output_file, crosstype, geno_file, founder_geno_file, gmap_file,
          sex_file, sex_covar, sex_codes,
          crossinfo_file, crossinfo_covar, crossinfo_codes,
          linemap_file, linemap_covar, geno_codes, alleles, xchr,
-         sep=",", na.strings=c("-", "NA"),
+         sep=",", na.strings=c("-", "NA"), comment.char="#",
          geno_transposed=FALSE, founder_geno_transposed=FALSE,
          pheno_transposed=FALSE, covar_transposed=FALSE,
          phenocovar_transposed=FALSE,
@@ -123,7 +125,8 @@ function(output_file, crosstype, geno_file, founder_geno_file, gmap_file,
     if(file.exists(output_file))
         stop("The output file (", output_file, ") already exists. Please remove it first.")
 
-    result <- list(crosstype=crosstype, sep=sep, na.strings=na.strings)
+    result <- list(crosstype=crosstype, sep=sep, na.strings=na.strings,
+                   comment.char=comment.char)
 
     if(!missing(geno_file))
         result$geno <- geno_file

--- a/man/write_control_file.Rd
+++ b/man/write_control_file.Rd
@@ -8,7 +8,7 @@ write_control_file(output_file, crosstype, geno_file, founder_geno_file,
   gmap_file, pmap_file, pheno_file, covar_file, phenocovar_file, sex_file,
   sex_covar, sex_codes, crossinfo_file, crossinfo_covar, crossinfo_codes,
   linemap_file, linemap_covar, geno_codes, alleles, xchr, sep = ",",
-  na.strings = c("-", "NA"), geno_transposed = FALSE,
+  na.strings = c("-", "NA"), comment.char = "#", geno_transposed = FALSE,
   founder_geno_transposed = FALSE, pheno_transposed = FALSE,
   covar_transposed = FALSE, phenocovar_transposed = FALSE, comments)
 }
@@ -83,6 +83,9 @@ alleles.}
 
 \item{na.strings}{Vector of character strings with codes to be
 treated as missing values.}
+
+\item{comment.char}{Character string that is used as initial
+character in a set of leading comment lines in the data files.}
 
 \item{geno_transposed}{If TRUE, genotype file is transposed (with markers as rows).}
 

--- a/tests/testthat/test-cbind_expand.R
+++ b/tests/testthat/test-cbind_expand.R
@@ -1,0 +1,49 @@
+context("cbind_expand")
+
+test_that("cbind_expand works", {
+
+    set.seed(20151109)
+    x <- data.frame(x=sample(LETTERS[1:5]), y=sample(letters[6:10]), stringsAsFactors=FALSE)
+    rownames(x) <- c("1", "3", "4", "5", "6")
+    y <- data.frame(a=runif(4), b=rnorm(4))
+    rownames(y) <- c("5", "2", "9", "4")
+
+    expected <- data.frame(x=c(x$x, NA, NA), y=c(x$y, NA, NA),
+                           a=rep(NA, 7), b=rep(NA, 7),
+                           stringsAsFactors=FALSE)
+    rownames(expected) <- c("1", "3", "4", "5", "6", "2", "9")
+    expected[rownames(y),"a"] <- y$a
+    expected[rownames(y),"b"] <- y$b
+
+
+    expect_equal(cbind_expand(x, y), expected)
+
+    # reverse inputs
+    expect_equal(cbind_expand(y, x), expected[c(4,6,7,3,1,2,5), c(3,4,1,2)])
+
+    # duplicate inputs
+    expect_equal(cbind_expand(x, x), cbind(x, x))
+    expect_equal(cbind_expand(y, y), cbind(y, y))
+
+    # expect error due to duplicate row names
+    expect_error(cbind_expand( rbind("1"=1:3, "1"=4:6), rbind("1"=4:9) ) )
+
+
+    # add a third input
+    z <- data.frame(c=sample(LETTERS[11:17]), d=sample(1L:5L, 7, replace=TRUE),
+                    stringsAsFactors=FALSE)
+    rownames(z) <- c("3", "1", "9", "4", "6", "5", "8")
+
+    expected <- data.frame(x=c(x$x, NA, NA, NA), y=c(x$y, NA, NA, NA),
+                           a=rep(NA, 8), b=rep(NA, 8),
+                           c=rep("", 8), d=rep(NA, 8),
+                           stringsAsFactors=FALSE)
+    rownames(expected) <- c("1", "3", "4", "5", "6", "2", "9", "8")
+    expected[rownames(y),"a"] <- y$a
+    expected[rownames(y),"b"] <- y$b
+    expected[rownames(z),"d"] <- z$d
+    expected[expected$c=="", "c"] <- NA
+    expected[rownames(z),"c"] <- z$c
+    expect_equal(cbind_expand(x, y, z), expected)
+
+})

--- a/tests/testthat/test-control_files.R
+++ b/tests/testthat/test-control_files.R
@@ -24,9 +24,9 @@ test_that("write_control_file gives correct output for riself", {
                                pheno = "grav2_pheno.csv", phenocovar = "grav2_phenocovar.csv",
                                gmap = "grav2_gmap.csv", alleles = c("L", "C"),
                                genotypes = structure(list(L = 1L, C = 2L), .Names = c("L", "C")),
-                               sep=",", na.strings = c("-", "NA")),
+                               sep=",", na.strings = c("-", "NA"), comment.char="#"),
                           .Names = c("crosstype", "geno", "pheno", "phenocovar",
-                          "gmap", "alleles", "genotypes", "sep", "na.strings"))
+                          "gmap", "alleles", "genotypes", "sep", "na.strings", "comment.char"))
 
     expect_equal(sort(names(control)), sort(names(expected)))
     expected <- expected[names(control)]
@@ -60,9 +60,9 @@ test_that("write_control_file in JSON for riself", {
                                gmap = "grav2_gmap.csv", alleles = c("L", "C"),
                                genotypes = structure(list(L = 1L, C = 2L), .Names = c("L", "C")),
                                sep=",",
-                               na.strings = c("-", "NA")),
+                               na.strings = c("-", "NA"), comment.char="#"),
                           .Names = c("crosstype", "geno", "pheno", "phenocovar",
-                          "gmap", "alleles", "genotypes", "sep", "na.strings"))
+                          "gmap", "alleles", "genotypes", "sep", "na.strings", "comment.char"))
 
     expect_equal(sort(names(control)), sort(names(expected)))
     expected <- expected[names(control)]
@@ -105,10 +105,10 @@ test_that("write_control_file gives correct output for intercross", {
                                .Names = c("covar", "f", "m")),
                                cross_info = structure(list(covar = "cross_direction", `(SxB)x(SxB)` = 0L, `(BxS)x(BxS)` = 1L),
                                .Names = c("covar", "(SxB)x(SxB)", "(BxS)x(BxS)")),
-                               x_chr = "X", sep=",", na.strings = c("-", "NA")),
+                               x_chr = "X", sep=",", na.strings = c("-", "NA"), comment.char="#"),
                           .Names = c("crosstype", "geno", "pheno", "phenocovar",
                           "covar", "gmap", "alleles", "genotypes", "sex", "cross_info",
-                          "x_chr", "sep", "na.strings"))
+                          "x_chr", "sep", "na.strings", "comment.char"))
 
     expect_equal(sort(names(control)), sort(names(expected)))
     expected <- expected[names(control)]
@@ -151,10 +151,10 @@ test_that("write_control_file in JSON intercross", {
                                .Names = c("covar", "f", "m")),
                                cross_info = structure(list(covar = "cross_direction", `(SxB)x(SxB)` = 0L, `(BxS)x(BxS)` = 1L),
                                .Names = c("covar", "(SxB)x(SxB)", "(BxS)x(BxS)")),
-                               x_chr = "X", sep=",", na.strings = c("-", "NA")),
+                               x_chr = "X", sep=",", na.strings = c("-", "NA"), comment.char="#"),
                           .Names = c("crosstype", "geno", "pheno", "phenocovar",
                           "covar", "gmap", "alleles", "genotypes", "sex", "cross_info",
-                          "x_chr", "sep", "na.strings"))
+                          "x_chr", "sep", "na.strings", "comment.char"))
 
     expect_equal(sort(names(control)), sort(names(expected)))
     expected <- expected[names(control)]

--- a/vignettes/input_files.Rmd
+++ b/vignettes/input_files.Rmd
@@ -107,8 +107,23 @@ files are each in the form of a simple matrix, with the first
 column being a set of IDs and the first row being a set of variable names.
 
 Missing value codes will be specified in the control file (as
-`na.strings`) and will apply across all files, so a missing value
+`na.strings`, with default value `"NA"`) and will apply across all files, so a missing value
 code for one file cannot be an allowed value in another file.
+
+The CSV files can include a header with a set of comment lines
+initiated by a value specified in the control file as `comment.char`
+(with default value `"#"`). The first such line could be a description
+of the contents of the file. These comment lines can include the
+expected number of rows and columns, like this:
+
+    # This file contains blah, blah, blah...
+    # nrow 25012
+    # ncol 91
+
+The number of rows (`nrow`) includes *only* the data rows (*not* the
+comment rows, *nor* the row with variable names). On the other hand, the
+number of columns (`ncol`) *does include* the column with individual
+IDs.
 
 All of these CSV files may be transposed relative to the form described
 below. You just need to include, in the control file, a line like


### PR DESCRIPTION
- Allow comment lines in the data files, including specifying the expected number of rows and columns.
- See examples in the files at https://github.com/rqtl/qtl2data/tree/master/DO_Gatti2014
- This fixes Issue #34.
- Also added a function `cbind_expand()` for column-binding matrices using rows as individual IDs and filling out rows with NAs as needed if some matrices are missing some individuals. (This is in preparation for allowing the data files to be split into multiple files.)
