### PR TITLE
Warn if unused fields in control file

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: qtl2geno
-Version: 0.3-17
-Date: 2015-11-09
+Version: 0.3-18
+Date: 2015-11-10
 Title: Treatment of Marker Genotypes for QTL Experiments
 Description: Functions to calculate QTL genotype probabilities, impute
     QTL genotypes, and estimate genetic maps. Part of R/qtl2, a

--- a/R/write_control_file.R
+++ b/R/write_control_file.R
@@ -122,16 +122,20 @@ function(output_file, crosstype, geno_file, founder_geno_file, gmap_file,
          geno_transposed=FALSE, founder_geno_transposed=FALSE,
          pheno_transposed=FALSE, covar_transposed=FALSE,
          phenocovar_transposed=FALSE,
-         description="", comments)
+         description, comments)
 {
     output_file <- path.expand(output_file)
     if(file.exists(output_file))
         stop("The output file (", output_file, ") already exists. Please remove it first.")
 
-    result <- list(description=paste(description, collapse="\n"),
+    result <- list(description="", # stub to be replaced or removed
                    comments="", # stub to be replaced or removed
                    crosstype=crosstype, sep=sep, na.strings=na.strings,
                    comment.char=comment.char)
+    if(missing(description) || is.null(description) || description=="")
+        result$description <- NULL
+    else
+        paste(description, collapse="\n")
 
     if(!missing(geno_file))
         result$geno <- geno_file
@@ -213,7 +217,9 @@ function(output_file, crosstype, geno_file, founder_geno_file, gmap_file,
 
     # JSON or YAML?
     if(grepl("\\.json$", output_file)) { # assume JSON
-        if(!missing(comments) && !is.null(comments))
+        if(missing(comments) || is.null(comments))
+            result$comments <- NULL
+        else
             result$comments <- comments
 
         cat(jsonlite::toJSON(result, auto_unbox=TRUE, pretty=TRUE),

--- a/R/write_control_file.R
+++ b/R/write_control_file.R
@@ -61,8 +61,11 @@
 #' @param pheno_transposed If TRUE, phenotype file is transposed (with phenotypes as rows).
 #' @param covar_transposed If TRUE, covariate file is transposed (with covariates as rows).
 #' @param phenocovar_transposed If TRUE, phenotype covariate file is transposed (with phenotype covariates as rows).
+#' @param description Optional character string describing the data.
 #' @param comments Vector of character strings to be inserted as
-#' comments at the top of the file, with each string as a line.
+#' comments at the top of the file (in the case of YAML), with each
+#' string as a line. For JSON, the comments are instead included
+#' within the control object.
 #'
 #' @return (Invisibly) The data structure that was written.
 #'
@@ -119,13 +122,15 @@ function(output_file, crosstype, geno_file, founder_geno_file, gmap_file,
          geno_transposed=FALSE, founder_geno_transposed=FALSE,
          pheno_transposed=FALSE, covar_transposed=FALSE,
          phenocovar_transposed=FALSE,
-         comments)
+         description="", comments)
 {
     output_file <- path.expand(output_file)
     if(file.exists(output_file))
         stop("The output file (", output_file, ") already exists. Please remove it first.")
 
-    result <- list(crosstype=crosstype, sep=sep, na.strings=na.strings,
+    result <- list(description=paste(description, collapse="\n"),
+                   comments="", # stub to be replaced or removed
+                   crosstype=crosstype, sep=sep, na.strings=na.strings,
                    comment.char=comment.char)
 
     if(!missing(geno_file))
@@ -216,6 +221,8 @@ function(output_file, crosstype, geno_file, founder_geno_file, gmap_file,
         cat("\n", file=output_file, append=TRUE) # add extra newline to avoid warning when reading
     }
     else {
+        result$comments <- NULL # delete the placeholder
+
         # comments as a single string
         if(missing(comments) || is.null(comments))
             comments <- ""
@@ -225,6 +232,5 @@ function(output_file, crosstype, geno_file, founder_geno_file, gmap_file,
         cat(comments, file=output_file)
         cat(yaml::as.yaml(result), file=output_file, append=TRUE)
     }
-
     invisible(result)
 }

--- a/man/write_control_file.Rd
+++ b/man/write_control_file.Rd
@@ -10,7 +10,8 @@ write_control_file(output_file, crosstype, geno_file, founder_geno_file,
   linemap_file, linemap_covar, geno_codes, alleles, xchr, sep = ",",
   na.strings = c("-", "NA"), comment.char = "#", geno_transposed = FALSE,
   founder_geno_transposed = FALSE, pheno_transposed = FALSE,
-  covar_transposed = FALSE, phenocovar_transposed = FALSE, comments)
+  covar_transposed = FALSE, phenocovar_transposed = FALSE,
+  description = "", comments)
 }
 \arguments{
 \item{output_file}{File name (with path) of the
@@ -97,8 +98,12 @@ character in a set of leading comment lines in the data files.}
 
 \item{phenocovar_transposed}{If TRUE, phenotype covariate file is transposed (with phenotype covariates as rows).}
 
+\item{description}{Optional character string describing the data.}
+
 \item{comments}{Vector of character strings to be inserted as
-comments at the top of the file, with each string as a line.}
+comments at the top of the file (in the case of YAML), with each
+string as a line. For JSON, the comments are instead included
+within the control object.}
 }
 \value{
 (Invisibly) The data structure that was written.

--- a/man/write_control_file.Rd
+++ b/man/write_control_file.Rd
@@ -10,8 +10,8 @@ write_control_file(output_file, crosstype, geno_file, founder_geno_file,
   linemap_file, linemap_covar, geno_codes, alleles, xchr, sep = ",",
   na.strings = c("-", "NA"), comment.char = "#", geno_transposed = FALSE,
   founder_geno_transposed = FALSE, pheno_transposed = FALSE,
-  covar_transposed = FALSE, phenocovar_transposed = FALSE,
-  description = "", comments)
+  covar_transposed = FALSE, phenocovar_transposed = FALSE, description,
+  comments)
 }
 \arguments{
 \item{output_file}{File name (with path) of the


### PR DESCRIPTION
- In `read_cross2`, if the control file contains unused fields, give a warning. Fixes issue #23.
- In `write_control_file`, move comments to top and allow description field; only include these if not empty.
