### PR TITLE
Cite version numbers in package dependencies

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: qtl2geno
-Version: 0.3-19
-Date: 2015-11-27
+Version: 0.3-20
+Date: 2015-12-01
 Title: Treatment of Marker Genotypes for QTL Experiments
 Description: Functions to calculate QTL genotype probabilities, impute
     QTL genotypes, and estimate genetic maps. Part of R/qtl2, a
@@ -11,10 +11,10 @@ Maintainer: Karl W Broman <kbroman@biostat.wisc.edu>
 Depends:
     R (>= 3.1.0)
 Imports:
-    Rcpp (>= 0.11.2),
-    yaml,
-    jsonlite,
-    data.table,
+    Rcpp (>= 0.12.1),
+    yaml (>= 2.1.13),
+    jsonlite (>= 0.9.17),
+    data.table (>= 1.9.4),
     parallel,
     stats,
     utils

--- a/man/calc_genoprob.Rd
+++ b/man/calc_genoprob.Rd
@@ -5,7 +5,7 @@
 \title{Calculate conditional genotype probabilities}
 \usage{
 calc_genoprob(cross, step = 0, off_end = 0, stepwidth = c("fixed", "max"),
-  pseudomarker_map, error_prob = 0.0001, map_function = c("haldane",
+  pseudomarker_map, error_prob = 1e-04, map_function = c("haldane",
   "kosambi", "c-f", "morgan"), quiet = TRUE, cores = 1)
 }
 \arguments{

--- a/man/est_map.Rd
+++ b/man/est_map.Rd
@@ -4,9 +4,8 @@
 \alias{est_map}
 \title{Estimate genetic maps}
 \usage{
-est_map(cross, error_prob = 0.0001, map_function = c("haldane", "kosambi",
-  "c-f", "morgan"), maxit = 10000, tol = 0.000001, quiet = TRUE,
-  cores = 1)
+est_map(cross, error_prob = 1e-04, map_function = c("haldane", "kosambi",
+  "c-f", "morgan"), maxit = 10000, tol = 1e-06, quiet = TRUE, cores = 1)
 }
 \arguments{
 \item{cross}{Object of class \code{"cross2"}. For details, see the

--- a/man/sim_geno.Rd
+++ b/man/sim_geno.Rd
@@ -5,7 +5,7 @@
 \title{Simulate genotypes given observed marker data}
 \usage{
 sim_geno(cross, n_draws = 1, step = 0, off_end = 0,
-  stepwidth = c("fixed", "max"), pseudomarker_map, error_prob = 0.0001,
+  stepwidth = c("fixed", "max"), pseudomarker_map, error_prob = 1e-04,
   map_function = c("haldane", "kosambi", "c-f", "morgan"), quiet = TRUE,
   cores = 1)
 }


### PR DESCRIPTION
Some of my code likely depends on recent version of jsonlite or data.table packages; best to make that explicit in the `DESCRIPTION` file. Some of the _latest_ versions are not available for Mac OS X Snow Leopard, so went with the most recent version available on all platforms.

Also, Roxygen2 made very minor changes to some `.Rd` files.
