### PR TITLE
Remove reliance on Fortran

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,5 +1,5 @@
 Package: qtl2geno
-Version: 0.3-20
+Version: 0.3-21
 Date: 2015-12-01
 Title: Treatment of Marker Genotypes for QTL Experiments
 Description: Functions to calculate QTL genotype probabilities, impute

--- a/ReadMe.md
+++ b/ReadMe.md
@@ -21,11 +21,7 @@ R/qtl2 is early in development and so is not yet available on
 
 You can install R/qtl2 from [GitHub](https://github.com/rqtl).
 
-You first need to install a Fortran compiler. See
-[Tools for Mac OS X](https://r.research.att.com/tools/) or
-[RTools for Windows](https://cran.r-project.org/bin/windows/Rtools/).
-
-You then need to install the
+You first need to install the
 [devtools](https://github.com/hadley/devtools) package, plus a set of
 package dependencies: [yaml](https://cran.r-project.org/package=yaml),
 [jsonlite](https://cran.r-project.org/package=jsonlite),
@@ -35,7 +31,7 @@ and [RcppEigen](https://github.com/RcppCore/RcppEigen).
 
     install.packages(c("devtools", "yaml", "jsonlite", "data.table", "RcppEigen"))
 
-Finally, install R/qtl2 using `devtools::install_github()`.
+Then, install R/qtl2 using `devtools::install_github()`.
 
     library(devtools)
     install_github(c("rqtl/qtl2geno", "rqtl/qtl2scan"))

--- a/man/calc_genoprob.Rd
+++ b/man/calc_genoprob.Rd
@@ -5,7 +5,7 @@
 \title{Calculate conditional genotype probabilities}
 \usage{
 calc_genoprob(cross, step = 0, off_end = 0, stepwidth = c("fixed", "max"),
-  pseudomarker_map, error_prob = 1e-04, map_function = c("haldane",
+  pseudomarker_map, error_prob = 0.0001, map_function = c("haldane",
   "kosambi", "c-f", "morgan"), quiet = TRUE, cores = 1)
 }
 \arguments{

--- a/man/est_map.Rd
+++ b/man/est_map.Rd
@@ -4,8 +4,9 @@
 \alias{est_map}
 \title{Estimate genetic maps}
 \usage{
-est_map(cross, error_prob = 1e-04, map_function = c("haldane", "kosambi",
-  "c-f", "morgan"), maxit = 10000, tol = 1e-06, quiet = TRUE, cores = 1)
+est_map(cross, error_prob = 0.0001, map_function = c("haldane", "kosambi",
+  "c-f", "morgan"), maxit = 10000, tol = 0.000001, quiet = TRUE,
+  cores = 1)
 }
 \arguments{
 \item{cross}{Object of class \code{"cross2"}. For details, see the

--- a/man/sim_geno.Rd
+++ b/man/sim_geno.Rd
@@ -5,7 +5,7 @@
 \title{Simulate genotypes given observed marker data}
 \usage{
 sim_geno(cross, n_draws = 1, step = 0, off_end = 0,
-  stepwidth = c("fixed", "max"), pseudomarker_map, error_prob = 1e-04,
+  stepwidth = c("fixed", "max"), pseudomarker_map, error_prob = 0.0001,
   map_function = c("haldane", "kosambi", "c-f", "morgan"), quiet = TRUE,
   cores = 1)
 }

--- a/src/Makevars
+++ b/src/Makevars
@@ -1,2 +1,0 @@
-PKG_LIBS = $(LAPACK_LIBS) $(BLAS_LIBS) $(FLIBS) 
-

--- a/vignettes/user_guide.Rmd
+++ b/vignettes/user_guide.Rmd
@@ -27,18 +27,19 @@ R/qtl2 is early in development and so is not yet available on
 
 You can install R/qtl2 from [GitHub](http://github.com/rqtl).
 
-You first need to install a Fortran compiler. See
-[Tools for Mac OS X](https://r.research.att.com/tools/) or
-[RTools for Windows](https://cran.r-project.org/bin/windows/Rtools/).
+You first need to install the
+[devtools](https://github.com/hadley/devtools) package, plus a set of
+package dependencies: [yaml](https://cran.r-project.org/package=yaml),
+[jsonlite](https://cran.r-project.org/package=jsonlite),
+[data.table](https://cran.r-project.org/package=data.table),
+and [RcppEigen](https://github.com/RcppCore/RcppEigen).
+(Additional, secondary dependencies will also be installed)
 
-You then need to install the
-[devtools](https://github.com/hadley/devtools) package.
-
-```{r install_devtools, eval=FALSE}
-install.packages("devtools")
+```{r install_devtools_and_dep, eval=FALSE}
+install.packages(c("devtools", "yaml", "jsonlite", "data.table", "RcppEigen"))
 ```
 
-Finally, install R/qtl2 using `devtools::install_github()`.
+Then, install R/qtl2 using `devtools::install_github()`.
 
 ```{r install_qtl2, eval=FALSE}
 library(devtools)


### PR DESCRIPTION
See [Issue 18 for qtl2scan](https://github.com/rqtl/qtl2scan/issues/18).

I should never have included the [`src/Makevars`](https://github.com/rqtl/qtl2geno/blob/0.3-20/src/Makevars) file that caused linking with LAPACK, BLAS, and the Fortran libraries, since I never used that in this package. I guess it was a leftover from before the split into [qtl2geno](https://github.com/rqtl/qtl2geno) and [qtl2scan](https://github.com/rqtl/qtl2scan).
