### PR TITLE
Add rownames to result of get_x_covar

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,5 +1,5 @@
 Package: qtl2geno
-Version: 0.3-21
+Version: 0.3-22
 Date: 2015-12-01
 Title: Treatment of Marker Genotypes for QTL Experiments
 Description: Functions to calculate QTL genotype probabilities, impute

--- a/R/get_x_covar.R
+++ b/R/get_x_covar.R
@@ -36,5 +36,13 @@ function(cross)
     if(class(cross) != "cross2")
         stop('Input cross must have class "cross2"')
 
-    .get_x_covar(cross$crosstype, cross$is_female, cross$cross_info)
+    x <- .get_x_covar(cross$crosstype, cross$is_female, cross$cross_info)
+
+    if(ncol(x)==0) return(NULL)
+
+    # add rownames
+    nam <- names(cross$is_female)
+    if(!is.null(nam)) rownames(x) <- nam
+
+    x
 }

--- a/R/get_x_covar.R
+++ b/R/get_x_covar.R
@@ -9,12 +9,12 @@
 #'
 #' @return A matrix of size individuals x no. covariates.
 #'
-#' @details For most crosses, the result is either a matrix with no
-#' columns (indicating no additional covariates are needed) or a
+#' @details For most crosses, the result is either \code{NULL}
+#' (indicating no additional covariates are needed) or a
 #' matrix with a single column containing sex indicators (1 for males
 #' and 0 for females).
 #'
-#'  For an intercross, we also consider cross direction. There are
+#' For an intercross, we also consider cross direction. There are
 #' four cases: (1) All male or all female but just one direction: no
 #' covariate; (2) All female but both directions: covariate indicating
 #' cross direction; (3) Both sexes, one direction: covariate

--- a/man/get_x_covar.Rd
+++ b/man/get_x_covar.Rd
@@ -18,12 +18,12 @@ Get the matrix of covariates to be used for the null hypothesis when
 performing QTL analysis with the X chromosome.
 }
 \details{
-For most crosses, the result is either a matrix with no
-columns (indicating no additional covariates are needed) or a
+For most crosses, the result is either \code{NULL}
+(indicating no additional covariates are needed) or a
 matrix with a single column containing sex indicators (1 for males
 and 0 for females).
 
- For an intercross, we also consider cross direction. There are
+For an intercross, we also consider cross direction. There are
 four cases: (1) All male or all female but just one direction: no
 covariate; (2) All female but both directions: covariate indicating
 cross direction; (3) Both sexes, one direction: covariate

--- a/tests/testthat/test-get_x_covar.R
+++ b/tests/testthat/test-get_x_covar.R
@@ -4,8 +4,7 @@ test_that("get_x_covar for riself", {
 
     grav2 <- read_cross2(system.file("extdata", "grav2.zip", package="qtl2geno"))
 
-    expect_equal(get_x_covar(grav2), matrix(0.0, ncol=0, nrow=n_ind(grav2)))
-
+    expect_equal(get_x_covar(grav2), NULL)
 
 })
 
@@ -17,31 +16,33 @@ test_that("get_x_covar for intercross", {
     expected <- matrix(0.0, ncol=2, nrow=n)
     expected[!iron$is_female, 1] <- 1.0
     expected[iron$is_female & iron$cross_info==1, 2] <- 1.0
+    rownames(expected) <- names(iron$is_female)
 
     expect_equal(get_x_covar(iron), expected)
 
     # all male
     tmp <- iron
     tmp$is_female <- rep(FALSE, length(tmp$is_female))
-    expect_equal(get_x_covar(tmp), matrix(0.0, ncol=0, nrow=n))
+    expect_equal(get_x_covar(tmp), NULL)
 
     # all female
     tmp <- iron
     tmp$is_female <- rep(TRUE, length(tmp$is_female))
     expected <- matrix(0.0, ncol=1, nrow=n)
     expected[iron$cross_info==1, 1] <- 1.0
+    rownames(expected) <- names(tmp$is_female)
     expect_equal(get_x_covar(tmp), expected)
 
     # all female, forward direction
     tmp <- iron
     tmp$is_female <- rep(TRUE, length(tmp$is_female))
     tmp$cross_info[tmp$cross_info==1] <- 0
-    expect_equal(get_x_covar(tmp), matrix(0.0, ncol=0, nrow=n))
+    expect_equal(get_x_covar(tmp), NULL)
 
     # all female, reverse direction
     tmp <- iron
     tmp$is_female <- rep(TRUE, length(tmp$is_female))
     tmp$cross_info[tmp$cross_info==0] <- 1
-    expect_equal(get_x_covar(tmp), matrix(0.0, ncol=0, nrow=n))
+    expect_equal(get_x_covar(tmp), NULL)
 
 })


### PR DESCRIPTION
- Also, if result has no columns, return `NULL` rather than a matrix with 0 columns
- We need the rownames in genome scans, to align with phenotypes, etc.
