### PR TITLE
Fix cryptic error message from read_cross2

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: qtl2geno
-Version: 0.3-22
-Date: 2015-12-01
+Version: 0.3-23
+Date: 2015-12-03
 Title: Treatment of Marker Genotypes for QTL Experiments
 Description: Functions to calculate QTL genotype probabilities, impute
     QTL genotypes, and estimate genetic maps. Part of R/qtl2, a

--- a/R/read_cross2.R
+++ b/R/read_cross2.R
@@ -581,7 +581,7 @@ function(filename, sep=",", na.strings=c("NA", "-"), comment.char="#", transpose
     }
 
     # move first column to row names
-    x <- firstcol2rownames(x)
+    x <- firstcol2rownames(x, filename)
 
     # transpose if requested
     if(transpose)

--- a/R/read_cross2.R
+++ b/R/read_cross2.R
@@ -328,10 +328,10 @@ function(mat, name="")
 check4duplicates <-
 function(ids, name="")
 {
-    if(name != "") name <- paste("in", name)
+    if(name != "") name <- paste(" in", name)
     dup <- duplicated(ids)
     if(any(dup)) {
-        stop("Not all ids in ", name, " are unique: ",
+        stop("Not all ids", name, " are unique: ",
              paste0('"', unique(ids[dup]), '"', collapse=", "))
     }
     TRUE


### PR DESCRIPTION
This fixes Issue #53. The problem was in the call from `read_csv()` to `firstcol2rownames()` (need to pass file name) and then in the call from `firstcol2rownames()` to `check4duplicates()` (the error message in `check4duplicates()` needed to be improved).

(_I'd thought that there was an issue with the name of the ID column in the files, but it turns out that the ID column can have any name, it just has to be the first column._)
