### PR TITLE
genoprob_to_alleleprob: fix treatment of X chromosome

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: qtl2geno
-Version: 0.3-25
-Date: 2015-12-05
+Version: 0.3-26
+Date: 2015-12-07
 Title: Treatment of Marker Genotypes for QTL Experiments
 Description: Functions to calculate QTL genotype probabilities, impute
     QTL genotypes, and estimate genetic maps. Part of R/qtl2, a

--- a/R/genoprob_to_alleleprob.R
+++ b/R/genoprob_to_alleleprob.R
@@ -47,7 +47,7 @@ genoprob_to_alleleprob <-
         probs[[chr]] <- aperm(.genoprob_to_alleleprob(attr(probs, "crosstype"),
                                                     aperm(probs[[chr]], c(2, 1, 3)), # reorg -> geno x ind x pos
                                                     is_x_chr[chr]),
-                            c(2, 1, 3))
+                            c(2, 1, 3)) # reorg back to ind x geno x pos
         dimnames(probs[[chr]]) <- attr_chr$dimnames
         probs[[chr]]
     }

--- a/src/cross_ail.cpp
+++ b/src/cross_ail.cpp
@@ -356,13 +356,13 @@ const int AIL::ngen(const bool is_x_chr)
 const NumericMatrix AIL::geno2allele_matrix(const bool is_x_chr)
 {
     if(is_x_chr) {
-        NumericMatrix result(5,4);
+        NumericMatrix result(5,2);
         result(0,0) = 1.0;               // AA female
         result(1,0) = result(1,1) = 0.5; // AB female
         result(2,1) = 1.0;               // BB female
 
-        result(3,2) = 1.0; // AY male
-        result(4,3) = 1.0; // BY male
+        result(3,0) = 1.0; // AY male
+        result(4,1) = 1.0; // BY male
 
         return result;
     }

--- a/src/cross_ailpk.cpp
+++ b/src/cross_ailpk.cpp
@@ -441,15 +441,15 @@ const double AILPK::est_rec_frac(const NumericVector& gamma, const bool is_x_chr
 const NumericMatrix AILPK::geno2allele_matrix(const bool is_x_chr)
 {
     if(is_x_chr) {
-        NumericMatrix result(6,4);
+        NumericMatrix result(6,2);
 
         result(0,0) = 1.0;               // AA female
         result(1,0) = result(1,1) = 0.5; // AB female
         result(2,0) = result(2,1) = 0.5; // BA female
         result(3,1) = 1.0;               // BB female
 
-        result(4,2) = 1.0; // AY male
-        result(5,3) = 1.0; // BY male
+        result(4,0) = 1.0; // AY male
+        result(5,1) = 1.0; // BY male
 
         return result;
     }

--- a/src/cross_do.cpp
+++ b/src/cross_do.cpp
@@ -261,7 +261,7 @@ const NumericMatrix DO::geno2allele_matrix(const bool is_x_chr)
     const int n_geno = 36;
 
     if(is_x_chr) {
-        NumericMatrix result(n_geno+n_alleles, n_alleles*2);
+        NumericMatrix result(n_geno+n_alleles, n_alleles);
         // female X
         for(int trueg=0; trueg<n_geno; trueg++) {
             IntegerVector alleles = decode_geno(trueg+1);
@@ -270,7 +270,7 @@ const NumericMatrix DO::geno2allele_matrix(const bool is_x_chr)
         }
         // male X
         for(int trueg=0; trueg<n_geno; trueg++)
-            result(trueg+n_geno, trueg+n_alleles) = 1.0;
+            result(trueg+n_geno, trueg) = 1.0;
 
         return result;
     }

--- a/src/cross_dopk.cpp
+++ b/src/cross_dopk.cpp
@@ -296,7 +296,7 @@ const NumericMatrix DOPK::geno2allele_matrix(const bool is_x_chr)
     const int n_geno = 64;
 
     if(is_x_chr) {
-        NumericMatrix result(n_geno+n_alleles, n_alleles*2);
+        NumericMatrix result(n_geno+n_alleles, n_alleles);
         // female X
         for(int trueg=0; trueg<n_geno; trueg++) {
             IntegerVector alleles = decode_geno(trueg+1);
@@ -305,7 +305,7 @@ const NumericMatrix DOPK::geno2allele_matrix(const bool is_x_chr)
         }
         // male X
         for(int trueg=0; trueg<n_geno; trueg++)
-            result(trueg+n_geno, trueg+n_alleles) = 1.0;
+            result(trueg+n_geno, trueg) = 1.0;
 
         return result;
     }

--- a/src/cross_f2.cpp
+++ b/src/cross_f2.cpp
@@ -199,7 +199,7 @@ const int F2::ngen(const bool is_x_chr)
 const NumericMatrix F2::geno2allele_matrix(const bool is_x_chr)
 {
     if(is_x_chr) { // X chr
-        NumericMatrix result(6,4);
+        NumericMatrix result(6,2);
         // female X
         result(0,0) = 1.0;
         result(1,0) = result(1,1) = 0.5;
@@ -207,7 +207,8 @@ const NumericMatrix F2::geno2allele_matrix(const bool is_x_chr)
         result(3,1) = 1.0;
 
         // male X
-        result(4,2) = result(5,3) = 1.0;
+        result(4,0) = 1.0;
+        result(5,1) = 1.0;
 
         return result;
     }

--- a/tests/testthat/test-calc_genetic_sim.R
+++ b/tests/testthat/test-calc_genetic_sim.R
@@ -53,9 +53,9 @@ test_that("calc_genetic_sim works for F2", {
         function(prob, x_chr=FALSE)
         {
             if(x_chr) {
-                prob[,1,] <- prob[,1,]+prob[,2,]/2+prob[,3,]/2
-                prob[,2,] <- prob[,4,]+prob[,2,]/2+prob[,3,]/2
-                return(prob[,-(3:4),])
+                prob[,1,] <- prob[,1,]+prob[,2,]/2+prob[,3,]/2+prob[,5,]
+                prob[,2,] <- prob[,4,]+prob[,2,]/2+prob[,3,]/2+prob[,6,]
+                return(prob[,1:2,])
 
             } else {
                 prob[,1,] <- prob[,1,]+prob[,2,]/2

--- a/tests/testthat/test-genoprob_to_alleleprob.R
+++ b/tests/testthat/test-genoprob_to_alleleprob.R
@@ -21,9 +21,9 @@ test_that("genoprob_to_alleleprob works for F2", {
         function(prob, x_chr=FALSE)
         {
             if(x_chr) {
-                prob[,1,] <- prob[,1,]+prob[,2,]/2+prob[,3,]/2
-                prob[,2,] <- prob[,4,]+prob[,2,]/2+prob[,3,]/2
-                return(prob[,-(3:4),])
+                prob[,1,] <- prob[,1,]+prob[,2,]/2+prob[,3,]/2 + prob[,5,]
+                prob[,2,] <- prob[,4,]+prob[,2,]/2+prob[,3,]/2 + prob[,6,]
+                return(prob[,1:2,])
 
             } else {
                 prob[,1,] <- prob[,1,]+prob[,2,]/2


### PR DESCRIPTION
- For intercross, AIL, and DO, I had been keeping male and female
  probabilities separate, so the result had 4 or 16 "alleles"
- Now merging the two sexes together, so that the result for all
  chromosomes has "allele" dimension 2 or 8.
