### PR TITLE
Include genotype names in calc_genoprob results

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: qtl2geno
-Version: 0.3-31
-Date: 2015-12-16
+Version: 0.3-32
+Date: 2016-02-19
 Title: Treatment of Marker Genotypes for QTL Experiments
 Description: Functions to calculate QTL genotype probabilities, impute
     QTL genotypes, and estimate genetic maps. Part of R/qtl2, a

--- a/R/RcppExports.R
+++ b/R/RcppExports.R
@@ -25,6 +25,10 @@ check_handle_x_chr <- function(crosstype, any_x_chr) {
     .Call('qtl2geno_check_handle_x_chr', PACKAGE = 'qtl2geno', crosstype, any_x_chr)
 }
 
+geno_names <- function(crosstype, alleles, is_x_chr) {
+    .Call('qtl2geno_geno_names', PACKAGE = 'qtl2geno', crosstype, alleles, is_x_chr)
+}
+
 .genoprob_to_alleleprob <- function(crosstype, prob_array, is_x_chr) {
     .Call('qtl2geno_genoprob_to_alleleprob', PACKAGE = 'qtl2geno', crosstype, prob_array, is_x_chr)
 }

--- a/R/calc_genoprob.R
+++ b/R/calc_genoprob.R
@@ -132,8 +132,21 @@ function(cross, step=0, off_end=0, stepwidth=c("fixed", "max"), pseudomarker_map
                 probs[[chr]][group[[i]],,] <- temp[[i]]
         }
 
+        # genotype names
+        alleles <- cross$alleles
+        if(is.null(alleles)) # no alleles saved; use caps
+            alleles <- LETTERS[1:ncol(probs[[chr]])]
+        gnames <- geno_names(cross$crosstype,
+                             alleles,
+                             cross$is_x_chr[chr])
+        if(length(gnames) != ncol(probs[[chr]])) {
+            warning("genotype names has length (", length(gnames),
+                    ") != genoprob dim (", ncol(probs[[chr]]), ")")
+            gnames <- NULL
+        }
+
         dimnames(probs[[chr]]) <- list(rownames(cross$geno[[chr]]),
-                                       NULL, # FIX ME: need genotype names in here
+                                       gnames,
                                        names(map[[chr]]))
 
     }
@@ -144,6 +157,7 @@ function(cross, step=0, off_end=0, stepwidth=c("fixed", "max"), pseudomarker_map
     attr(probs, "crosstype") <- cross$crosstype
     attr(probs, "sex") <- cross$sex
     attr(probs, "cross_info") <- cross$cross_info
+    attr(probs, "alleles") <- cross$alleles
 
     class(probs) <- c("calc_genoprob", "list")
 

--- a/R/convert2cross2.R
+++ b/R/convert2cross2.R
@@ -88,6 +88,9 @@ function(cross)
         storage.mode(result$pheno) <- "double"
     }
 
+    # alleles
+    result$alleles <- attr(cross, "alleles")
+
     class(result) <- "cross2"
 
     check_cross2(result) # double-check

--- a/R/genoprob_to_alleleprob.R
+++ b/R/genoprob_to_alleleprob.R
@@ -42,7 +42,12 @@ genoprob_to_alleleprob <-
                                                     aperm(probs[[chr]], c(2, 1, 3)), # reorg -> geno x ind x pos
                                                     is_x_chr[chr]),
                             c(2, 1, 3)) # reorg back to ind x geno x pos
-        dimnames(probs[[chr]]) <- attr_chr$dimnames
+
+        # allele names
+        dn <- attr_chr$dimnames
+        dn[[2]] <- attr(probs, "alleles")
+        dimnames(probs[[chr]]) <- dn
+
         probs[[chr]]
     }
 

--- a/src/RcppExports.cpp
+++ b/src/RcppExports.cpp
@@ -80,6 +80,19 @@ BEGIN_RCPP
     return __result;
 END_RCPP
 }
+// geno_names
+std::vector<std::string> geno_names(const String& crosstype, const std::vector<std::string> alleles, const bool is_x_chr);
+RcppExport SEXP qtl2geno_geno_names(SEXP crosstypeSEXP, SEXP allelesSEXP, SEXP is_x_chrSEXP) {
+BEGIN_RCPP
+    Rcpp::RObject __result;
+    Rcpp::RNGScope __rngScope;
+    Rcpp::traits::input_parameter< const String& >::type crosstype(crosstypeSEXP);
+    Rcpp::traits::input_parameter< const std::vector<std::string> >::type alleles(allelesSEXP);
+    Rcpp::traits::input_parameter< const bool >::type is_x_chr(is_x_chrSEXP);
+    __result = Rcpp::wrap(geno_names(crosstype, alleles, is_x_chr));
+    return __result;
+END_RCPP
+}
 // genoprob_to_alleleprob
 NumericVector genoprob_to_alleleprob(const String& crosstype, const NumericVector& prob_array, const bool is_x_chr);
 RcppExport SEXP qtl2geno_genoprob_to_alleleprob(SEXP crosstypeSEXP, SEXP prob_arraySEXP, SEXP is_x_chrSEXP) {

--- a/src/cross.h
+++ b/src/cross.h
@@ -202,6 +202,22 @@ public:
         return result;
     }
 
+    // genotype names from allele names
+    // default version is A,B -> AA,BB
+    virtual const std::vector<std::string> geno_names(const std::vector<std::string> alleles,
+                                                      const bool is_x_chr)
+    {
+        if(alleles.size() < 2)
+            throw std::range_error("alleles must have length 2");
+
+        std::vector<std::string> result(2);
+        for(int i=0; i<2; i++) {
+            result[i] = alleles[i] + alleles[i];
+        }
+        return result;
+    }
+
+
 };
 
 #endif // CROSS_H

--- a/src/cross_ail.cpp
+++ b/src/cross_ail.cpp
@@ -468,3 +468,28 @@ const bool AIL::check_crossinfo(const IntegerMatrix& cross_info, const bool any_
     }
     return result;
 }
+
+// geno_names from allele names
+const std::vector<std::string> AIL::geno_names(const std::vector<std::string> alleles,
+                                               const bool is_x_chr)
+{
+    if(alleles.size() < 2)
+        throw std::range_error("alleles must have length 2");
+
+    if(is_x_chr) {
+        std::vector<std::string> result(5);
+        result[0] = alleles[0] + alleles[0];
+        result[1] = alleles[0] + alleles[1];
+        result[2] = alleles[1] + alleles[1];
+        result[3] = alleles[0] + "Y";
+        result[4] = alleles[1] + "Y";
+        return result;
+    }
+    else {
+        std::vector<std::string> result(3);
+        result[0] = alleles[0] + alleles[0];
+        result[1] = alleles[0] + alleles[1];
+        result[2] = alleles[1] + alleles[1];
+        return result;
+    }
+}

--- a/src/cross_ail.h
+++ b/src/cross_ail.h
@@ -36,6 +36,7 @@ class AIL : public QTLCross
 
     const bool check_crossinfo(const Rcpp::IntegerMatrix& cross_info, const bool any_x_chr);
 
+    const std::vector<std::string> geno_names(const std::vector<std::string> alleles, const bool is_x_chr);
 };
 
 #endif // CROSS_AIL_H

--- a/src/cross_bc.cpp
+++ b/src/cross_bc.cpp
@@ -143,3 +143,26 @@ const bool BC::check_is_female_vector(const LogicalVector& is_female, const bool
     }
     return result;
 }
+
+// geno_names from allele names
+const std::vector<std::string> BC::geno_names(const std::vector<std::string> alleles,
+                                              const bool is_x_chr)
+{
+    if(alleles.size() < 2)
+        throw std::range_error("alleles must have length 2");
+
+    if(is_x_chr) {
+        std::vector<std::string> result(4);
+        result[0] = alleles[0] + alleles[0];
+        result[1] = alleles[0] + alleles[1];
+        result[2] = alleles[0] + "Y";
+        result[3] = alleles[1] + "Y";
+        return result;
+    }
+    else {
+        std::vector<std::string> result(2);
+        result[0] = alleles[0] + alleles[0];
+        result[1] = alleles[0] + alleles[1];
+        return result;
+    }
+}

--- a/src/cross_bc.h
+++ b/src/cross_bc.h
@@ -36,6 +36,9 @@ class BC : public QTLCross
 
     const bool check_is_female_vector(const Rcpp::LogicalVector& is_female, const bool any_x_chr);
 
+    const std::vector<std::string> geno_names(const std::vector<std::string> alleles,
+                                              const bool is_x_chr);
+
 };
 
 #endif // CROSS_BC_H

--- a/src/cross_do.cpp
+++ b/src/cross_do.cpp
@@ -554,3 +554,32 @@ const bool DO::need_founder_geno()
 {
     return true;
 }
+
+// geno_names from allele names
+const std::vector<std::string> DO::geno_names(const std::vector<std::string> alleles,
+                                              const bool is_x_chr)
+{
+    if(alleles.size() < 8)
+        throw std::range_error("alleles must have length 8");
+
+    if(is_x_chr) {
+        std::vector<std::string> result(44);
+        for(int i=0; i<36; i++) {
+            IntegerVector allele_int = DO::decode_geno(i+1);
+            result[i] = alleles[allele_int[0]-1] + alleles[allele_int[1]-1];
+        }
+        for(int i=0; i<8; i++) {
+            result[36+i] = alleles[i] + "Y";
+        }
+
+        return result;
+    }
+    else {
+        std::vector<std::string> result(36);
+        for(int i=0; i<36; i++) {
+            IntegerVector allele_int = DO::decode_geno(i+1);
+            result[i] = alleles[allele_int[0]-1] + alleles[allele_int[1]-1];
+        }
+        return result;
+    }
+}

--- a/src/cross_do.h
+++ b/src/cross_do.h
@@ -53,6 +53,7 @@ class DO : public QTLCross
     const bool check_founder_geno_values(const Rcpp::IntegerMatrix& founder_geno);
     const bool need_founder_geno();
 
+    const std::vector<std::string> geno_names(const std::vector<std::string> alleles, const bool is_x_chr);
 };
 
 #endif // CROSS_DO_H

--- a/src/cross_f2.cpp
+++ b/src/cross_f2.cpp
@@ -359,12 +359,13 @@ const std::vector<std::string> F2::geno_names(const std::vector<std::string> all
         throw std::range_error("alleles must have length 2");
 
     if(is_x_chr) {
-        std::vector<std::string> result(5);
+        std::vector<std::string> result(6);
         result[0] = alleles[0] + alleles[0];
         result[1] = alleles[0] + alleles[1];
-        result[2] = alleles[1] + alleles[1];
-        result[3] = alleles[0] + "Y";
-        result[4] = alleles[1] + "Y";
+        result[2] = alleles[1] + alleles[0];
+        result[3] = alleles[1] + alleles[1];
+        result[4] = alleles[0] + "Y";
+        result[5] = alleles[1] + "Y";
         return result;
     }
     else {

--- a/src/cross_f2.cpp
+++ b/src/cross_f2.cpp
@@ -349,3 +349,29 @@ const NumericMatrix F2::get_x_covar(const LogicalVector& is_female, const Intege
         }
     }
 }
+
+
+// geno_names from allele names
+const std::vector<std::string> F2::geno_names(const std::vector<std::string> alleles,
+                                              const bool is_x_chr)
+{
+    if(alleles.size() < 2)
+        throw std::range_error("alleles must have length 2");
+
+    if(is_x_chr) {
+        std::vector<std::string> result(5);
+        result[0] = alleles[0] + alleles[0];
+        result[1] = alleles[0] + alleles[1];
+        result[2] = alleles[1] + alleles[1];
+        result[3] = alleles[0] + "Y";
+        result[4] = alleles[1] + "Y";
+        return result;
+    }
+    else {
+        std::vector<std::string> result(3);
+        result[0] = alleles[0] + alleles[0];
+        result[1] = alleles[0] + alleles[1];
+        result[2] = alleles[1] + alleles[1];
+        return result;
+    }
+}

--- a/src/cross_f2.h
+++ b/src/cross_f2.h
@@ -37,6 +37,8 @@ class F2 : public QTLCross
     const bool check_crossinfo(const Rcpp::IntegerMatrix& cross_info, const bool any_x_chr);
 
     const Rcpp::NumericMatrix get_x_covar(const Rcpp::LogicalVector& is_female, const Rcpp::IntegerMatrix& cross_info);
+
+    const std::vector<std::string> geno_names(const std::vector<std::string> alleles, const bool is_x_chr);
 };
 
 #endif // CROSS_F2_H

--- a/src/cross_haploid.cpp
+++ b/src/cross_haploid.cpp
@@ -1,0 +1,18 @@
+// haploid QTLCross class (for HMM)
+
+#include "cross_haploid.h"
+#include <Rcpp.h>
+#include "cross.h"
+
+// geno_names from allele names
+const std::vector<std::string> HAPLOID::geno_names(const std::vector<std::string> alleles,
+                                                   const bool is_x_chr)
+{
+    if(alleles.size() < 2)
+        throw std::range_error("alleles must have length 2");
+
+    std::vector<std::string> result(2);
+    result[0] = alleles[0];
+    result[1] = alleles[1];
+    return result;
+}

--- a/src/cross_haploid.h
+++ b/src/cross_haploid.h
@@ -27,8 +27,8 @@ class HAPLOID : public QTLCross
         return true; // most crosses can handle the X chr
     }
 
-    // the rest of the functions match the defaults,
-    // so there's no cross_dh.cpp file
+    const std::vector<std::string> geno_names(const std::vector<std::string> alleles,
+                                              const bool is_x_chr);
 };
 
 #endif // CROSS_HAPLOID_H

--- a/src/geno_names.cpp
+++ b/src/geno_names.cpp
@@ -1,0 +1,18 @@
+// genotype names from alleles
+
+#include "geno_names.h"
+#include <Rcpp.h>
+#include "cross.h"
+
+// [[Rcpp::export]]
+std::vector<std::string> geno_names(const String& crosstype,
+                                    const std::vector<std::string> alleles,
+                                    const bool is_x_chr)
+{
+    QTLCross* cross = QTLCross::Create(crosstype);
+    std::vector<std::string> result = cross->geno_names(alleles, is_x_chr);
+
+    delete cross;
+
+    return result;
+}

--- a/src/geno_names.h
+++ b/src/geno_names.h
@@ -1,0 +1,11 @@
+// genotype names from alleles
+#ifndef GENO_NAMES_H
+#define GENO_NAMES_H
+
+#include <Rcpp.h>
+
+std::vector<std::string> geno_names(const Rcpp::String& crosstype,
+                                    const std::vector<std::string> alleles,
+                                    const bool is_x_chr);
+
+#endif // GENO_NAMES_H

--- a/tests/testthat/test-genoprob_to_alleleprob.R
+++ b/tests/testthat/test-genoprob_to_alleleprob.R
@@ -6,8 +6,13 @@ test_that("genoprob_to_alleleprob works for RIL", {
     probs <- calc_genoprob(grav2, step=1, error_prob=0.002)
     allele_probs <- genoprob_to_alleleprob(probs)
 
-    attr(probs, "alleles") <- TRUE # should be only difference between the two
-    expect_equal(allele_probs, probs)
+    # expected result, hardly changed
+    expected <- probs
+    attr(expected, "alleles") <- TRUE
+    for(i in 1:length(probs))
+        colnames(expected[[i]]) <- c("L", "C")
+
+    expect_equal(allele_probs, expected)
 
 })
 
@@ -21,14 +26,20 @@ test_that("genoprob_to_alleleprob works for F2", {
         function(prob, x_chr=FALSE)
         {
             if(x_chr) {
+                cn <- colnames(prob)
                 prob[,1,] <- prob[,1,]+prob[,2,]/2+prob[,3,]/2 + prob[,5,]
                 prob[,2,] <- prob[,4,]+prob[,2,]/2+prob[,3,]/2 + prob[,6,]
-                return(prob[,1:2,])
+                prob <- prob[,1:2,]
+                colnames(prob) <- substr(cn[c(1,3)], 1, 1)
+                return(prob)
 
             } else {
+                cn <- colnames(prob)
                 prob[,1,] <- prob[,1,]+prob[,2,]/2
                 prob[,2,] <- prob[,3,]+prob[,2,]/2
-                return(prob[,1:2,])
+                prob <- prob[,1:2,]
+                colnames(prob) <- substr(cn[c(1,3)], 1, 1)
+                return(prob)
             }
         }
 

--- a/tests/testthat/test-hmmbasic-ail.R
+++ b/tests/testthat/test-hmmbasic-ail.R
@@ -285,3 +285,8 @@ test_that("AIL step works", {
 
 
 })
+
+test_that("geno_names works", {
+    expect_equal(geno_names("ail", c("B", "R"), FALSE), c("BB", "BR", "RR"))
+    expect_equal(geno_names("ail", c("B", "R"), TRUE), c("BB", "BR", "RR", "BY", "RY"))
+})

--- a/tests/testthat/test-hmmbasic-bc.R
+++ b/tests/testthat/test-hmmbasic-bc.R
@@ -1,4 +1,3 @@
-
 context("basic HMM functions in backcross")
 
 test_that("backcross check_geno works", {
@@ -150,4 +149,9 @@ test_that("backcross step works", {
     expect_equal(test_step("bc", 4, 3, rf, TRUE, FALSE, integer(0)), log(rf))
     expect_equal(test_step("bc", 4, 4, rf, TRUE, FALSE, integer(0)), log(1-rf))
 
+})
+
+test_that("geno_names works", {
+    expect_equal(geno_names("bc", c("B", "R"), FALSE), c("BB", "BR"))
+    expect_equal(geno_names("bc", c("B", "R"), TRUE), c("BB", "BR", "BY", "RY"))
 })

--- a/tests/testthat/test-hmmbasic-dh.R
+++ b/tests/testthat/test-hmmbasic-dh.R
@@ -1,4 +1,3 @@
-
 context("basic HMM functions in doubled haploids")
 
 test_that("doubled haploids check_geno works", {
@@ -67,4 +66,9 @@ test_that("doubled haploids step works", {
     expect_equal(test_step("dh", 2, 1, rf, FALSE, FALSE, integer(0)), log(rf))
     expect_equal(test_step("dh", 2, 2, rf, FALSE, FALSE, integer(0)), log(1-rf))
 
+})
+
+test_that("geno_names works", {
+    expect_equal(geno_names("dh", c("B", "R"), FALSE), c("BB", "RR"))
+    expect_equal(geno_names("dh", c("B", "R"), TRUE), c("BB", "RR"))
 })

--- a/tests/testthat/test-hmmbasic-do.R
+++ b/tests/testthat/test-hmmbasic-do.R
@@ -222,3 +222,14 @@ test_that("DO step works", {
     }
 
 })
+
+test_that("geno_names works", {
+    auto <- c("AA", "AB", "BB", "AC", "BC", "CC", "AD", "BD", "CD", "DD",
+              "AE", "BE", "CE", "DE", "EE", "AF", "BF", "CF", "DF", "EF", "FF",
+              "AG", "BG", "CG", "DG", "EG", "FG", "GG", "AH", "BH", "CH", "DH",
+              "EH", "FH", "GH", "HH")
+    X <- c(auto, paste0(LETTERS[1:8], "Y"))
+
+    expect_equal(geno_names("do", LETTERS[1:8], FALSE), auto)
+    expect_equal(geno_names("do", LETTERS[1:8], TRUE), X)
+})

--- a/tests/testthat/test-hmmbasic-f2.R
+++ b/tests/testthat/test-hmmbasic-f2.R
@@ -220,5 +220,5 @@ test_that("intercross step works", {
 
 test_that("geno_names works", {
     expect_equal(geno_names("f2", c("B", "R"), FALSE), c("BB", "BR", "RR"))
-    expect_equal(geno_names("f2", c("B", "R"), TRUE), c("BB", "BR", "RR", "BY", "RY"))
+    expect_equal(geno_names("f2", c("B", "R"), TRUE), c("BB", "BR", "RB", "RR", "BY", "RY"))
 })

--- a/tests/testthat/test-hmmbasic-f2.R
+++ b/tests/testthat/test-hmmbasic-f2.R
@@ -1,4 +1,3 @@
-
 context("basic HMM functions in intercross")
 
 test_that("intercross check_geno works", {
@@ -217,4 +216,9 @@ test_that("intercross step works", {
     expect_equal(test_step("f2", 6, 5, rf, TRUE, FALSE, 1), log(rf))
     expect_equal(test_step("f2", 6, 6, rf, TRUE, FALSE, 1), log(1-rf))
 
+})
+
+test_that("geno_names works", {
+    expect_equal(geno_names("f2", c("B", "R"), FALSE), c("BB", "BR", "RR"))
+    expect_equal(geno_names("f2", c("B", "R"), TRUE), c("BB", "BR", "RR", "BY", "RY"))
 })

--- a/tests/testthat/test-hmmbasic-haploid.R
+++ b/tests/testthat/test-hmmbasic-haploid.R
@@ -1,4 +1,3 @@
-
 context("basic HMM functions in haploids")
 
 test_that("haploids check_geno works", {
@@ -67,4 +66,9 @@ test_that("haploids step works", {
     expect_equal(test_step("haploid", 2, 1, rf, FALSE, FALSE, integer(0)), log(rf))
     expect_equal(test_step("haploid", 2, 2, rf, FALSE, FALSE, integer(0)), log(1-rf))
 
+})
+
+test_that("geno_names works", {
+    expect_equal(geno_names("haploid", c("B", "R"), FALSE), c("B", "R"))
+    expect_equal(geno_names("haploid", c("B", "R"), TRUE), c("B", "R"))
 })

--- a/tests/testthat/test-hmmbasic-riself.R
+++ b/tests/testthat/test-hmmbasic-riself.R
@@ -1,4 +1,3 @@
-
 context("basic HMM functions in riself")
 
 test_that("riself check_geno works", {
@@ -66,4 +65,9 @@ test_that("riself step works", {
     expect_equal(test_step("riself", 2, 1, rf, FALSE, FALSE, integer(0)), log(RF))
     expect_equal(test_step("riself", 2, 2, rf, FALSE, FALSE, integer(0)), log(1-RF))
 
+})
+
+test_that("geno_names works", {
+    expect_equal(geno_names("riself", c("B", "R"), FALSE), c("BB", "RR"))
+    expect_equal(geno_names("riself", c("B", "R"), TRUE), c("BB", "RR"))
 })

--- a/tests/testthat/test-hmmbasic-risib.R
+++ b/tests/testthat/test-hmmbasic-risib.R
@@ -1,4 +1,3 @@
-
 context("basic HMM functions in risib")
 
 test_that("risib check_geno works", {
@@ -151,4 +150,9 @@ test_that("risib step works", {
     expect_equal(test_step("risib", 2, 1, rf, TRUE, FALSE, 1), log(t12))
     expect_equal(test_step("risib", 2, 2, rf, TRUE, FALSE, 1), log(t11))
 
+})
+
+test_that("geno_names works", {
+    expect_equal(geno_names("risib", c("B", "R"), FALSE), c("BB", "RR"))
+    expect_equal(geno_names("risib", c("B", "R"), TRUE), c("BB", "RR"))
 })

--- a/tests/testthat/test-subset.R
+++ b/tests/testthat/test-subset.R
@@ -63,17 +63,17 @@ test_that("subset.calc_genoprob works", {
     iron <- read_cross2(system.file("extdata", "iron.zip", package="qtl2geno"))
     ironsub <- iron[,c(4,"X")]
 
-    pr <- calc_genoprob(iron, step=5, err=0.01)
+    pr <- calc_genoprob(ironsub, step=5, err=0.01)
     prsub <- pr[,"X"]
 
     at <- attributes(pr)
     expected <- unclass(pr)["X"]
     attr(expected, "is_x_chr") <- at$is_x_chr["X"]
     attr(expected, "map") <- at$map["X"]
-    attr(expected, "map") <- at$map["X"]
     attr(expected, "crosstype") <- at$crosstype
     attr(expected, "cross_info") <- at$cross_info
     attr(expected, "class") <- at$class
+    attr(expected, "alleles") <- at$alleles
 
     expect_equal(prsub, expected)
 


### PR DESCRIPTION
- Add `geno_names()` function for each cross type
- Add genotype names as columns to `calc_genoprob` output; also need to include `alleles` as an attribute.
- In `genoprobs_to_alleleprobs()`, set column names to allele names.
