### PR TITLE
genoprob_to_alleleprob: change attribute "alleles" to "alleleprobs"

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: qtl2geno
-Version: 0.3-32
-Date: 2016-02-19
+Version: 0.3-33
+Date: 2016-02-22
 Title: Treatment of Marker Genotypes for QTL Experiments
 Description: Functions to calculate QTL genotype probabilities, impute
     QTL genotypes, and estimate genetic maps. Part of R/qtl2, a

--- a/R/calc_kinship.R
+++ b/R/calc_kinship.R
@@ -73,6 +73,10 @@ calc_kinship <-
 
     # convert from genotype probabilities to allele probabilities
     if(use_allele_probs) {
+        # already converted?
+        ap_attr <- attr(probs, "alleleprobs")
+        if(!is.null(ap_attr) && ap_attr) break # already converted
+
         if(!quiet) message(" - converting to allele probs")
         probs <- genoprob_to_alleleprob(probs, quiet=quiet, cores=cores)
     }

--- a/R/genoprob_to_alleleprob.R
+++ b/R/genoprob_to_alleleprob.R
@@ -26,6 +26,10 @@
 genoprob_to_alleleprob <-
     function(probs, quiet=TRUE, cores=1)
 {
+    # already converted?
+    ap_attr <- attr(probs, "alleleprobs")
+    if(!is.null(ap_attr) && ap_attr) return(probs)
+
     is_x_chr <- attr(probs, "is_x_chr")
 
     # set up cluster; make quiet=FALSE if cores>1
@@ -58,6 +62,6 @@ genoprob_to_alleleprob <-
 
     for(at in names(probs_attr))
         attr(probs, at) <- probs_attr[[at]]
-    attr(probs, "alleles") <- TRUE
+    attr(probs, "alleleprobs") <- TRUE
     probs
 }

--- a/tests/testthat/test-genoprob_to_alleleprob.R
+++ b/tests/testthat/test-genoprob_to_alleleprob.R
@@ -8,7 +8,7 @@ test_that("genoprob_to_alleleprob works for RIL", {
 
     # expected result, hardly changed
     expected <- probs
-    attr(expected, "alleles") <- TRUE
+    attr(expected, "alleleprobs") <- TRUE
     for(i in 1:length(probs))
         colnames(expected[[i]]) <- c("L", "C")
 
@@ -47,7 +47,7 @@ test_that("genoprob_to_alleleprob works for F2", {
     is_x_chr <- attr(probs, "is_x_chr")
     for(i in seq(along=probs)) # loop over chromosomes
         expected[[i]] <- f2_geno2alle(probs[[i]], is_x_chr[i])
-    attr(expected, "alleles") <- TRUE
+    attr(expected, "alleleprobs") <- TRUE
 
     expect_equal(allele_probs, expected)
 


### PR DESCRIPTION
- after converting genotype probabilities to allele probabilities, we
  set an attribute "alleles" to TRUE, but this conflicts with the new
  attribute we have, of the single-letter allele codes
- So, make the "alleleprobs" attribute the indicator of whether the
  probabilities are for alleles
- Also, use this in calc_kinship to avoid trying to convert genotype
  probabilities to allele probabilities. (Really just avoid making a
  copy, since genoprob_to_alleleprob already does this check.)
