### PR TITLE
Fix calc_kinship

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: qtl2geno
-Version: 0.3-35
-Date: 2016-02-24
+Version: 0.3-36
+Date: 2016-02-25
 Title: Treatment of Marker Genotypes for QTL Experiments
 Description: Functions to calculate QTL genotype probabilities, impute
     QTL genotypes, and estimate genetic maps. Part of R/qtl2, a

--- a/R/calc_kinship.R
+++ b/R/calc_kinship.R
@@ -35,12 +35,12 @@
 #' @details If \code{use_allele_probs=TRUE} (the default), we first
 #' convert the genotype probabilities are converted to allele
 #' probabilities (using \code{\link{genoprob_to_alleleprob}}). This is
-#' recommended, as then the result is like a empirical kinship
+#' recommended, as then the result is twice the empirical kinship
 #' coefficient (e.g., the expected value for an intercross is 1/2;
 #' using genotype probabilities, the expected value is 3/8).
 #'
 #' We then calculate
-#' \eqn{\sum_{kl}(p_{ikl} p_{jkl})}{sum_kl (p_ikl p_jkl)}
+#' \eqn{2 \sum_{kl}(p_{ikl} p_{jkl})}{2 sum_kl (p_ikl p_jkl)}
 #' where \eqn{k} = position, \eqn{l} = allele, and \eqn{i,j}
 #' are two individuals.
 #'
@@ -62,7 +62,7 @@
 
 calc_kinship <-
     function(probs, type=c("overall", "loco", "chr"),
-             use_grid_only=TRUE, omit_x=TRUE,
+             use_grid_only=TRUE, omit_x=FALSE,
              use_allele_probs=TRUE,
              normalize=TRUE,
              quiet=TRUE, cores=1)
@@ -224,6 +224,6 @@ normalize_kinship <-
     }
 
     n <- nrow(kinship)
-    norm_const <- (n - sum(kinship)/n) / (n-1)
+    norm_const <- (sum(diag(kinship)) - sum(kinship)/n) / (n-1)
     kinship/norm_const
 }

--- a/man/calc_kinship.Rd
+++ b/man/calc_kinship.Rd
@@ -5,7 +5,7 @@
 \title{Calculate kinship matrix}
 \usage{
 calc_kinship(probs, type = c("overall", "loco", "chr"),
-  use_grid_only = TRUE, omit_x = TRUE, use_allele_probs = TRUE,
+  use_grid_only = TRUE, omit_x = FALSE, use_allele_probs = TRUE,
   normalize = TRUE, quiet = TRUE, cores = 1)
 }
 \arguments{
@@ -53,12 +53,12 @@ from conditional genotype probabilities.
 If \code{use_allele_probs=TRUE} (the default), we first
 convert the genotype probabilities are converted to allele
 probabilities (using \code{\link{genoprob_to_alleleprob}}). This is
-recommended, as then the result is like a empirical kinship
+recommended, as then the result is twice the empirical kinship
 coefficient (e.g., the expected value for an intercross is 1/2;
 using genotype probabilities, the expected value is 3/8).
 
 We then calculate
-\eqn{\sum_{kl}(p_{ikl} p_{jkl})}{sum_kl (p_ikl p_jkl)}
+\eqn{2 \sum_{kl}(p_{ikl} p_{jkl})}{2 sum_kl (p_ikl p_jkl)}
 where \eqn{k} = position, \eqn{l} = allele, and \eqn{i,j}
 are two individuals.
 

--- a/src/calc_kinship.cpp
+++ b/src/calc_kinship.cpp
@@ -21,9 +21,7 @@ NumericMatrix calc_kinship(const NumericVector& prob_array) // array as n_pos x 
     NumericMatrix result(n_ind, n_ind);
 
     for(unsigned int ind_i=0, offset_i=0; ind_i<n_ind; ++ind_i, offset_i += pos_by_gen) {
-        result(ind_i,ind_i) = (double)n_pos;
-
-        for(unsigned int ind_j=ind_i+1, offset_j=(ind_i+1)*pos_by_gen; ind_j<n_ind; ind_j++, offset_j += pos_by_gen) {
+        for(unsigned int ind_j=ind_i, offset_j=ind_i*pos_by_gen; ind_j<n_ind; ind_j++, offset_j += pos_by_gen) {
 
             double total = 0.0;
             for(unsigned int pos=0; pos<n_pos; pos++) {
@@ -32,7 +30,8 @@ NumericMatrix calc_kinship(const NumericVector& prob_array) // array as n_pos x 
                         prob_array[pos + gen*n_pos + offset_j];
                 }
             }
-            result(ind_i,ind_j) = result(ind_j,ind_i) = total;
+            // calculating 2*kinship = 2*Pr(random allele from i == random allele from j)
+            result(ind_i,ind_j) = result(ind_j,ind_i) = 2*total;
         }
     }
 


### PR DESCRIPTION
- Explicitly calculate the values on the diagonal (which concern the varying levels of homozygosity)
- Return twice the empirical kinship coefficient, as that's what's used in the linear mixed models
- New default of `omit_x=FALSE`.
