### PR TITLE
Change calc_kinship back

### DIFF
--- a/R/calc_kinship.R
+++ b/R/calc_kinship.R
@@ -50,7 +50,7 @@
 #'
 #' If \code{normalize=TRUE} (the default), we normalize the kinship matrix as in
 #' equation 5 in Kang et al. (2010) Nat Genet
-#' 42:348-354. \href{http://www.nature.com/ng/journal/v42/n4/full/ng.548.html}{doi: 10.1038/ng.548}
+#' 42:348-354. \href{http://www.ncbi.nlm.nih.gov/pubmed/20208533}{doi: 10.1038/ng.548}
 #'
 #' @export
 #' @keywords utilities

--- a/R/calc_kinship.R
+++ b/R/calc_kinship.R
@@ -40,7 +40,7 @@
 #' using genotype probabilities, the expected value is 3/8).
 #'
 #' We then calculate
-#' \eqn{2 \sum_{kl}(p_{ikl} p_{jkl})}{2 sum_kl (p_ikl p_jkl)}
+#' \eqn{\sum_{kl}(p_{ikl} p_{jkl})}{sum_kl (p_ikl p_jkl)}
 #' where \eqn{k} = position, \eqn{l} = allele, and \eqn{i,j}
 #' are two individuals.
 #'
@@ -48,7 +48,7 @@
 #' don't convert to allele probabilities but just use the original
 #' genotype probabilities.
 #'
-#' If \code{normalize=TRUE}, we normalize the kinship matrix as in
+#' If \code{normalize=TRUE} (the default), we normalize the kinship matrix as in
 #' equation 5 in Kang et al. (2010) Nat Genet
 #' 42:348-354. \href{http://doi.org/10.1038/ng.548}{doi: 10.1038/ng.548}
 #'

--- a/R/calc_kinship.R
+++ b/R/calc_kinship.R
@@ -50,7 +50,7 @@
 #'
 #' If \code{normalize=TRUE} (the default), we normalize the kinship matrix as in
 #' equation 5 in Kang et al. (2010) Nat Genet
-#' 42:348-354. \href{http://doi.org/10.1038/ng.548}{doi: 10.1038/ng.548}
+#' 42:348-354. \href{http://www.nature.com/ng/journal/v42/n4/full/ng.548.html}{doi: 10.1038/ng.548}
 #'
 #' @export
 #' @keywords utilities

--- a/man/calc_kinship.Rd
+++ b/man/calc_kinship.Rd
@@ -68,7 +68,7 @@ genotype probabilities.
 
 If \code{normalize=TRUE} (the default), we normalize the kinship matrix as in
 equation 5 in Kang et al. (2010) Nat Genet
-42:348-354. \href{http://www.nature.com/ng/journal/v42/n4/full/ng.548.html}{doi: 10.1038/ng.548}
+42:348-354. \href{http://www.ncbi.nlm.nih.gov/pubmed/20208533}{doi: 10.1038/ng.548}
 }
 \examples{
 grav2 <- read_cross2(system.file("extdata", "grav2.zip", package="qtl2geno"))

--- a/man/calc_kinship.Rd
+++ b/man/calc_kinship.Rd
@@ -58,7 +58,7 @@ coefficient (e.g., the expected value for an intercross is 1/2;
 using genotype probabilities, the expected value is 3/8).
 
 We then calculate
-\eqn{2 \sum_{kl}(p_{ikl} p_{jkl})}{2 sum_kl (p_ikl p_jkl)}
+\eqn{\sum_{kl}(p_{ikl} p_{jkl})}{sum_kl (p_ikl p_jkl)}
 where \eqn{k} = position, \eqn{l} = allele, and \eqn{i,j}
 are two individuals.
 
@@ -66,7 +66,7 @@ For crosses with just two possible genotypes (e.g., backcross), we
 don't convert to allele probabilities but just use the original
 genotype probabilities.
 
-If \code{normalize=TRUE}, we normalize the kinship matrix as in
+If \code{normalize=TRUE} (the default), we normalize the kinship matrix as in
 equation 5 in Kang et al. (2010) Nat Genet
 42:348-354. \href{http://doi.org/10.1038/ng.548}{doi: 10.1038/ng.548}
 }

--- a/man/calc_kinship.Rd
+++ b/man/calc_kinship.Rd
@@ -68,7 +68,7 @@ genotype probabilities.
 
 If \code{normalize=TRUE} (the default), we normalize the kinship matrix as in
 equation 5 in Kang et al. (2010) Nat Genet
-42:348-354. \href{http://doi.org/10.1038/ng.548}{doi: 10.1038/ng.548}
+42:348-354. \href{http://www.nature.com/ng/journal/v42/n4/full/ng.548.html}{doi: 10.1038/ng.548}
 }
 \examples{
 grav2 <- read_cross2(system.file("extdata", "grav2.zip", package="qtl2geno"))

--- a/src/calc_kinship.cpp
+++ b/src/calc_kinship.cpp
@@ -31,8 +31,7 @@ NumericMatrix calc_kinship(const NumericVector& prob_array) // array as n_pos x 
                         prob_array[pos + gen*n_pos + offset_j];
                 }
             }
-            // calculating 2*kinship = 2*Pr(random allele from i == random allele from j)
-            result(ind_i,ind_j) = result(ind_j,ind_i) = 2*total;
+            result(ind_i,ind_j) = result(ind_j,ind_i) = total;
         }
     }
 

--- a/tests/testthat/test-calc_kinship.R
+++ b/tests/testthat/test-calc_kinship.R
@@ -30,7 +30,7 @@ test_that("calc_kinship works for RIL", {
     tot_pos <- 0
     for(i in seq(along=probs)) {
         for(k in seq(along=pairs))
-            expected[k] <- expected[k] + 2*sum(probs_sub[[i]][pairs[[k]][1],,] * probs_sub[[i]][pairs[[k]][2],,])
+            expected[k] <- expected[k] + sum(probs_sub[[i]][pairs[[k]][1],,] * probs_sub[[i]][pairs[[k]][2],,])
         tot_pos <- tot_pos + dim(probs_sub[[i]])[3]
     }
     expected <- expected/tot_pos
@@ -90,7 +90,7 @@ test_that("calc_kinship (unnormalized) works for F2", {
         }
         tot_pos <- tot_pos + dim(probs_sub[[i]])[3]
     }
-    expected <- 2*expected/tot_pos
+    expected <- expected/tot_pos
     for(k in seq(along=pairs))
         expect_equal(sim[pairs[[k]][1],pairs[[k]][2]], expected[k])
 
@@ -111,7 +111,7 @@ test_that("calc_kinship (unnormalized) works for F2", {
         }
         tot_pos <- tot_pos + dim(probs_sub[[i]])[3]
     }
-    expected <- 2*expected/tot_pos
+    expected <- expected/tot_pos
     for(k in seq(along=pairs))
         expect_equal(sim[pairs[[k]][1],pairs[[k]][2]], expected[k])
 
@@ -146,7 +146,7 @@ test_that("calc_kinship (unnormalized) works for F2", {
         }
         tot_pos <- tot_pos + dim(probs_sub[[i]])[3]
     }
-    expected <- 2*expected/tot_pos
+    expected <- expected/tot_pos
     for(k in seq(along=pairs)) {
         expect_equal(sim[pairs[[k]][1],pairs[[k]][2]], expected[k])
     }
@@ -168,7 +168,7 @@ test_that("calc_kinship (unnormalized) works for F2", {
         }
         tot_pos <- tot_pos + dim(probs_sub[[i]])[3]
     }
-    expected <- 2*expected/tot_pos
+    expected <- expected/tot_pos
     for(k in seq(along=pairs))
         expect_equal(sim[pairs[[k]][1],pairs[[k]][2]], expected[k])
 


### PR DESCRIPTION
- Had previous changed `calc_kinship()` to return 2x the kinship matrix (but then normalized). Changed this back, since when we normalize, it makes no difference.
- Fix url for Kang et al (2010) paper to avoid warning from `R CMD check`.
