### PR TITLE
Add c++ functions nalleles() for each cross type

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: qtl2geno
-Version: 0.3-36
-Date: 2016-02-25
+Version: 0.3-37
+Date: 2016-03-02
 Title: Treatment of Marker Genotypes for QTL Experiments
 Description: Functions to calculate QTL genotype probabilities, impute
     QTL genotypes, and estimate genetic maps. Part of R/qtl2, a

--- a/R/RcppExports.R
+++ b/R/RcppExports.R
@@ -29,6 +29,10 @@ geno_names <- function(crosstype, alleles, is_x_chr) {
     .Call('qtl2geno_geno_names', PACKAGE = 'qtl2geno', crosstype, alleles, is_x_chr)
 }
 
+nalleles <- function(crosstype) {
+    .Call('qtl2geno_nalleles', PACKAGE = 'qtl2geno', crosstype)
+}
+
 .genoprob_to_alleleprob <- function(crosstype, prob_array, is_x_chr) {
     .Call('qtl2geno_genoprob_to_alleleprob', PACKAGE = 'qtl2geno', crosstype, prob_array, is_x_chr)
 }

--- a/R/read_cross2.R
+++ b/R/read_cross2.R
@@ -213,9 +213,15 @@ function(file, quiet=TRUE)
     used_control["linemap"] <- TRUE # indicate that we used it
 
     # alleles?
+    n_alleles <- nalleles(crosstype)
     if("alleles" %in% names(control)) {
         output$alleles <- control$alleles
         used_control["alleles"] <- TRUE # indicate that we used it
+        if(n_alleles != length(output$alleles))
+            stop("length(alleles) [", length(output$alleles),
+                 "] != expected number [", n_alleles, "]")
+    } else {
+        output$alleles <- LETTERS[1:n_alleles]
     }
 
     class(output) <- "cross2"

--- a/R/read_cross2.R
+++ b/R/read_cross2.R
@@ -213,7 +213,7 @@ function(file, quiet=TRUE)
     used_control["linemap"] <- TRUE # indicate that we used it
 
     # alleles?
-    n_alleles <- nalleles(crosstype)
+    n_alleles <- nalleles(output$crosstype)
     if("alleles" %in% names(control)) {
         output$alleles <- control$alleles
         used_control["alleles"] <- TRUE # indicate that we used it

--- a/src/RcppExports.cpp
+++ b/src/RcppExports.cpp
@@ -93,6 +93,17 @@ BEGIN_RCPP
     return __result;
 END_RCPP
 }
+// nalleles
+int nalleles(const String& crosstype);
+RcppExport SEXP qtl2geno_nalleles(SEXP crosstypeSEXP) {
+BEGIN_RCPP
+    Rcpp::RObject __result;
+    Rcpp::RNGScope __rngScope;
+    Rcpp::traits::input_parameter< const String& >::type crosstype(crosstypeSEXP);
+    __result = Rcpp::wrap(nalleles(crosstype));
+    return __result;
+END_RCPP
+}
 // genoprob_to_alleleprob
 NumericVector genoprob_to_alleleprob(const String& crosstype, const NumericVector& prob_array, const bool is_x_chr);
 RcppExport SEXP qtl2geno_genoprob_to_alleleprob(SEXP crosstypeSEXP, SEXP prob_arraySEXP, SEXP is_x_chrSEXP) {

--- a/src/cross.h
+++ b/src/cross.h
@@ -80,6 +80,11 @@ public:
         return 2;
     }
 
+    virtual const int nalleles()
+    {
+        return 2;
+    }
+
     virtual const Rcpp::IntegerVector possible_gen(const bool is_x_chr, const bool is_female,
                                                    const Rcpp::IntegerVector& cross_info)
     {

--- a/src/cross_do.cpp
+++ b/src/cross_do.cpp
@@ -255,6 +255,11 @@ const int DO::ngen(const bool is_x_chr)
     return n_geno;
 }
 
+const int DO::nalleles()
+{
+    return 8;
+}
+
 const NumericMatrix DO::geno2allele_matrix(const bool is_x_chr)
 {
     const int n_alleles = 8;

--- a/src/cross_do.h
+++ b/src/cross_do.h
@@ -29,6 +29,7 @@ class DO : public QTLCross
     const Rcpp::IntegerVector possible_gen(const bool is_x_chr, const bool is_female, const Rcpp::IntegerVector& cross_info);
 
     const int ngen(const bool is_x_chr);
+    const int nalleles();
 
     const Rcpp::NumericMatrix geno2allele_matrix(const bool is_x_chr);
 
@@ -54,6 +55,7 @@ class DO : public QTLCross
     const bool need_founder_geno();
 
     const std::vector<std::string> geno_names(const std::vector<std::string> alleles, const bool is_x_chr);
+
 };
 
 #endif // CROSS_DO_H

--- a/src/cross_dopk.cpp
+++ b/src/cross_dopk.cpp
@@ -274,6 +274,11 @@ const int DOPK::ngen(const bool is_x_chr)
     return n_geno;
 }
 
+const int DOPK::nalleles()
+{
+    return 8;
+}
+
 const double DOPK::nrec(const int gen_left, const int gen_right,
                         const bool is_x_chr, const bool is_female,
                         const IntegerVector& cross_info)

--- a/src/cross_dopk.h
+++ b/src/cross_dopk.h
@@ -29,6 +29,7 @@ class DOPK : public QTLCross
     const Rcpp::IntegerVector possible_gen(const bool is_x_chr, const bool is_female, const Rcpp::IntegerVector& cross_info);
 
     const int ngen(const bool is_x_chr);
+    const int nalleles();
 
     const double nrec(const int gen_left, const int gen_right,
                       const bool is_x_chr, const bool is_female, const Rcpp::IntegerVector& cross_info);

--- a/src/geno_names.cpp
+++ b/src/geno_names.cpp
@@ -16,3 +16,14 @@ std::vector<std::string> geno_names(const String& crosstype,
 
     return result;
 }
+
+// [[Rcpp::export]]
+int nalleles(const String& crosstype)
+{
+    QTLCross* cross = QTLCross::Create(crosstype);
+    int result = cross->nalleles();
+
+    delete cross;
+
+    return result;
+}

--- a/tests/testthat/test-hmmbasic-ail.R
+++ b/tests/testthat/test-hmmbasic-ail.R
@@ -1,5 +1,9 @@
 context("basic HMM functions in AIL")
 
+test_that("AIL nalleles works", {
+    expect_equal(nalleles("ail"), 2)
+})
+
 test_that("AIL check_geno works", {
 
     # autosome

--- a/tests/testthat/test-hmmbasic-ailpk.R
+++ b/tests/testthat/test-hmmbasic-ailpk.R
@@ -1,5 +1,9 @@
 context("basic HMM functions in phase-known AIL")
 
+test_that("phase-known AIL nalleles works", {
+    expect_equal(nalleles("ailpk"), 2)
+})
+
 test_that("phase-known AIL check_geno works", {
 
     # autosome

--- a/tests/testthat/test-hmmbasic-bc.R
+++ b/tests/testthat/test-hmmbasic-bc.R
@@ -1,5 +1,9 @@
 context("basic HMM functions in backcross")
 
+test_that("backcross nalleles works", {
+    expect_equal(nalleles("bc"), 2)
+})
+
 test_that("backcross check_geno works", {
 
     # autosome

--- a/tests/testthat/test-hmmbasic-dh.R
+++ b/tests/testthat/test-hmmbasic-dh.R
@@ -1,5 +1,9 @@
 context("basic HMM functions in doubled haploids")
 
+test_that("doubled haploids nalleles works", {
+    expect_equal(nalleles("dh"), 2)
+})
+
 test_that("doubled haploids check_geno works", {
 
     # autosome

--- a/tests/testthat/test-hmmbasic-do.R
+++ b/tests/testthat/test-hmmbasic-do.R
@@ -1,5 +1,9 @@
 context("basic HMM functions in Diversity Outcross")
 
+test_that("DO nalleles works", {
+    expect_equal(nalleles("do"), 8)
+})
+
 test_that("DO check_geno works", {
 
     # observed genotypes

--- a/tests/testthat/test-hmmbasic-dopk.R
+++ b/tests/testthat/test-hmmbasic-dopk.R
@@ -1,5 +1,9 @@
 context("basic HMM functions in phase-known Diversity Outcross")
 
+test_that("Phase-known DO nalleles works", {
+    expect_equal(nalleles("dopk"), 8)
+})
+
 test_that("Phase-known DO check_geno works", {
 
     # observed genotypes

--- a/tests/testthat/test-hmmbasic-f2.R
+++ b/tests/testthat/test-hmmbasic-f2.R
@@ -1,5 +1,9 @@
 context("basic HMM functions in intercross")
 
+test_that("intercross nalleles works", {
+    expect_equal(nalleles("f2"), 2)
+})
+
 test_that("intercross check_geno works", {
 
     # autosome

--- a/tests/testthat/test-hmmbasic-f2pk.R
+++ b/tests/testthat/test-hmmbasic-f2pk.R
@@ -1,5 +1,8 @@
-
 context("basic HMM functions in phase-known intercross")
+
+test_that("p-k intercross nalleles works", {
+    expect_equal(nalleles("f2pk"), 2)
+})
 
 test_that("p-k intercross check_geno works", {
 

--- a/tests/testthat/test-hmmbasic-haploid.R
+++ b/tests/testthat/test-hmmbasic-haploid.R
@@ -1,5 +1,9 @@
 context("basic HMM functions in haploids")
 
+test_that("haploids nalleles works", {
+    expect_equal(nalleles("haploid"), 2)
+})
+
 test_that("haploids check_geno works", {
 
     # autosome

--- a/tests/testthat/test-hmmbasic-riself.R
+++ b/tests/testthat/test-hmmbasic-riself.R
@@ -1,5 +1,9 @@
 context("basic HMM functions in riself")
 
+test_that("riself nalleles works", {
+    expect_equal(nalleles("riself"), 2)
+})
+
 test_that("riself check_geno works", {
 
     expect_true(test_check_geno("riself", 0, TRUE, FALSE, FALSE, integer(0)))

--- a/tests/testthat/test-hmmbasic-risib.R
+++ b/tests/testthat/test-hmmbasic-risib.R
@@ -1,5 +1,9 @@
 context("basic HMM functions in risib")
 
+test_that("risib nalleles works", {
+    expect_equal(nalleles("risib"), 2)
+})
+
 test_that("risib check_geno works", {
 
     # autosome


### PR DESCRIPTION
Also, in `read_cross2()`, force inclusion of an `alleles` component with single-letter allele codes.

I need this in [R/qtl2scan](https://github.com/rqtl/qtl2scan).
