### PR TITLE
Remove chrID and indID from calc_genoprob and sim_geno objects

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: qtl2geno
-Version: 0.4-4
-Date: 2016-03-07
+Version: 0.4-5
+Date: 2016-03-08
 Title: Treatment of Marker Genotypes for QTL Experiments
 Description: Functions to calculate QTL genotype probabilities, impute
     QTL genotypes, and estimate genetic maps. Part of R/qtl2, a

--- a/R/calc_genoprob.R
+++ b/R/calc_genoprob.R
@@ -36,8 +36,6 @@
 #' \item \code{grid} - A list of logical vectors, indicating which
 #'     positions correspond to a grid of markers/pseudomarkers. (may be
 #'     absent)
-#' \item \code{indID} - Vector of character strings with individual IDs
-#' \item \code{chrID} - Vector of character strings with chromosome IDs
 #' \item \code{crosstype} - The cross type of the input \code{cross}.
 #' \item \code{is_x_chr} - Logical vector indicating whether chromosomes
 #'     are to be treated as the X chromosome or not, from input \code{cross}.
@@ -180,8 +178,6 @@ function(cross, step=0, off_end=0, stepwidth=c("fixed", "max"), pseudomarker_map
     names(probs) <- names(cross$gmap)
     result <- list(probs=probs,
                    map=map,
-                   indID=rownames(probs[[1]]),
-                   chrID=names(probs),
                    crosstype=cross$crosstype,
                    is_x_chr=cross$is_x_chr,
                    sex=cross$sex,

--- a/R/calc_kinship.R
+++ b/R/calc_kinship.R
@@ -106,7 +106,7 @@ calc_kinship <-
 calc_kinship_overall <-
     function(probs, chrs, quiet=TRUE, cores=1)
 {
-    ind_names <- probs$indID
+    ind_names <- rownames(probs$probs[[1]])
     n_ind <- length(ind_names)
 
     result <- matrix(0, nrow=n_ind, ncol=n_ind)
@@ -121,7 +121,7 @@ calc_kinship_overall <-
 
     # function that does the work
     by_chr_func <- function(chr) {
-        if(!quiet) message(" - Chr ", probs$chrID[chr])
+        if(!quiet) message(" - Chr ", names(probs$probs)[chr])
         pr <- aperm(probs$probs[[chr]], c(3,2,1)) # convert to pos x gen x ind
         .calc_kinship(pr)
     }
@@ -148,7 +148,7 @@ calc_kinship_overall <-
 calc_kinship_bychr <-
     function(probs, chrs, scale=TRUE, quiet=TRUE, cores=1)
 {
-    ind_names <- probs$indID
+    ind_names <- rownames(probs$probs[[1]])
     n_ind <- length(ind_names)
 
     # set up cluster and set quiet=TRUE if multi-core
@@ -160,7 +160,7 @@ calc_kinship_bychr <-
 
     # function that does the work
     by_chr_func <- function(chr) {
-        if(!quiet) message(" - Chr ", probs$chrID[chr])
+        if(!quiet) message(" - Chr ", names(probs$probs)[chr])
 
         n_pos <- dim(probs$probs[[chr]])[3]
 
@@ -177,7 +177,7 @@ calc_kinship_bychr <-
     # run and combine results
     result <- cluster_lapply(cores, chrs, by_chr_func)
 
-    names(result) <- probs$chrID[chrs]
+    names(result) <- names(probs$probs)[chrs]
     result
 }
 

--- a/R/genoprob_to_alleleprob.R
+++ b/R/genoprob_to_alleleprob.R
@@ -40,7 +40,7 @@ genoprob_to_alleleprob <-
     }
 
     by_chr_func <- function(chr) {
-        if(!quiet) message(" - Chr ", probs$chrID[chr])
+        if(!quiet) message(" - Chr ", names(probs$probs)[chr])
         result <- aperm(.genoprob_to_alleleprob(probs$crosstype,
                                                 aperm(probs$probs[[chr]], c(2, 1, 3)), # reorg -> geno x ind x pos
                                                 is_x_chr[chr]),
@@ -54,10 +54,12 @@ genoprob_to_alleleprob <-
         result
     }
 
-    chrs <- seq(along=probs$chrID)
+    chrID <- names(probs$probs)
+    chrs <- seq(along=chrID)
+
 
     probs$probs <- cluster_lapply(cores, chrs, by_chr_func) # if cores==1, this uses lapply()
-    names(probs$probs) <- probs$chrID
+    names(probs$probs) <- chrID
 
     probs$alleleprobs <- TRUE
     probs

--- a/R/probs_to_grid.R
+++ b/R/probs_to_grid.R
@@ -40,21 +40,22 @@ probs_to_grid <-
     if(is.null(probs$grid))
         stop("probs has no grid attribute")
 
-    for(i in seq(along=probs$chrID)) {
+    chrID <- names(probs$probs)
+    for(i in seq(along=chrID)) {
         # grab grid vector
         if(is.null(grid[[i]])) {
-            stop("grid not found for chr ", probs$chrID[i])
+            stop("grid not found for chr ", chrID[i])
         }
         if(length(grid[[i]]) != length(map[[i]])) {
             stop("length(grid) [", length(grid[[i]]), "] != length(map) [",
-                 length(map[[i]]), "] for chr ", probs$chrID[i])
+                 length(map[[i]]), "] for chr ", chrID[i])
         }
 
         # subset probs
         if(!all(grid[[i]])) {
             if(length(grid[[i]]) != dim(probs$probs[[i]])[3])
                 stop("length(grid) [", length(grid[[i]]), "] != ncol(probs) [",
-                     ncol(probs$probs[[i]]), "] for chr ", probs$chrID[i])
+                     ncol(probs$probs[[i]]), "] for chr ", chrID[i])
             probs$probs[[i]] <- probs$probs[[i]][,,grid[[i]],drop=FALSE]
         }
     }

--- a/R/sim_geno.R
+++ b/R/sim_geno.R
@@ -37,8 +37,6 @@
 #' \item \code{grid} - A list of logical vectors, indicating which
 #'     positions correspond to a grid of markers/pseudomarkers. (may be
 #'     absent)
-#' \item \code{indID} - Vector of character strings with individual IDs
-#' \item \code{chrID} - Vector of character strings with chromosome IDs
 #' \item \code{crosstype} - The cross type of the input \code{cross}.
 #' \item \code{is_x_chr} - Logical vector indicating whether chromosomes
 #'     are to be treated as the X chromosome or not, from input \code{cross}.
@@ -155,8 +153,6 @@ function(cross, n_draws=1, step=0, off_end=0, stepwidth=c("fixed", "max"), pseud
     names(draws) <- names(cross$gmap)
     result <- list(draws=draws,
                    map = map,
-                   indID = rownames(draws[[1]]),
-                   chrID = names(map),
                    crosstype = cross$crosstype,
                    is_x_chr = cross$is_x_chr,
                    sex = cross$sex,

--- a/R/subset_calc_genoprob.R
+++ b/R/subset_calc_genoprob.R
@@ -33,53 +33,57 @@ subset.calc_genoprob <-
        (missing(chr) || is.null(chr)))
         stop("You must specify either ind or chr.")
 
+    chrID <- names(x$probs)
+    n_chr <- length(chrID)
     if(!missing(chr) && !is.null(chr)) {
         if(is.logical(chr)) {
-            if(length(chr) != length(x$chrID)) {
+            if(length(chr) != n_chr) {
                 stop("length(chr) [", length(chr), "] != no. chr in x [",
-                     length(x$chrID), "]")
+                     n_chr, "]")
             }
-            chr <- x$chrID[chr] # convert to character strings
+            chr <- chrID[chr] # convert to character strings
         }
         else {
-            chrindex <- match(chr, x$chrID)
+            chrindex <- match(chr, chrID)
             if(any(is.na(chrindex))) {
                 stop("Some chr not found: ",
                      paste(chr[is.na(chrindex)], collapse=", "))
             }
-            chr <- x$chrID[chrindex] # character strings
+            chr <- chrID[chrindex] # character strings
         }
         if(length(chr) == 0)
             stop("Must retain at least one chromosome.")
 
         to_sub <- c("probs", "draws", "map", "is_x_chr", "grid", "snpinfo") # draws is here, to also deal with sim_geno objects
         for(a in to_sub) {
-            if(a %in% names(x))
+            if(a %in% names(x)) {
                 x[[a]] <- x[[a]][chr]
+            }
         }
-        x$chrID <- chr
     }
 
+    indID <- rownames(x$probs[[1]])
+    n_ind <- length(indID)
     if(!missing(ind) && !is.null(ind)) {
         if(is.logical(ind)) {
-            if(length(ind) != length(x$indID)) {
+            if(length(ind) != n_ind) {
                 stop("length(ind) [", length(ind), "] != no. ind in x [",
-                     length(x$indID), "]")
+                     n_ind, "]")
             }
-            ind <- x$indID[ind] # convert to character strings
+            ind <- indID[ind] # convert to character strings
         }
         else if(is.numeric(ind)) {
-            if(any(ind < 1 || ind > length(x$indID)))
-                stop("Numeric ind out of allowed range [1 - ", length(x$indID), "]")
-            ind <- x$indID[ind] # convert to character strings
+            if(any(ind < 1 || ind > n_ind))
+                stop("Numeric ind out of allowed range [1 - ", n_ind, "]")
+            ind <- indID[ind] # convert to character strings
         }
         else {
-            indindex <- match(ind, x$indID)
+            indindex <- match(ind, indID)
             if(any(is.na(indindex))) {
                 stop("Some individuals not found: ",
                      paste(ind[is.na(indindex)], collapse=", "))
             }
-            ind <- x$indID[indindex]
+            ind <- indID[indindex]
         }
         if(length(ind) == 0)
             stop("Must retain at least one individual.")
@@ -87,13 +91,12 @@ subset.calc_genoprob <-
         to_sub_mat <- c("probs", "draws") # draws is here to also handle sim_geno objects
         for(a in to_sub_mat) {
             if(a %in% names(x)) {
-                for(i in x$chrID)
+                for(i in names(x$probs)) # loop over chromosomes
                     x[[a]][[i]] <- x[[a]][[i]][ind,,,drop=FALSE]
             }
         }
         if(!is.null(x$cross_info))
             x$cross_info <- x$cross_info[ind, , drop=FALSE]
-        x$indID <- ind
     }
 
     x

--- a/R/subset_calc_genoprob.R
+++ b/R/subset_calc_genoprob.R
@@ -33,67 +33,74 @@ subset.calc_genoprob <-
        (missing(chr) || is.null(chr)))
         stop("You must specify either ind or chr.")
 
+    chrID <- names(x$map)
+    n_chr <- length(chrID)
     if(!missing(chr) && !is.null(chr)) {
         if(is.logical(chr)) {
-            if(length(chr) != length(x$chrID)) {
+            if(length(chr) != n_chr) {
                 stop("length(chr) [", length(chr), "] != no. chr in x [",
-                     length(x$chrID), "]")
+                     n_chr, "]")
             }
-            chr <- x$chrID[chr] # convert to character strings
+            chr <- chrID[chr] # convert to character strings
         }
         else {
-            chrindex <- match(chr, x$chrID)
+            chrindex <- match(chr, chrID)
             if(any(is.na(chrindex))) {
                 stop("Some chr not found: ",
                      paste(chr[is.na(chrindex)], collapse=", "))
             }
-            chr <- x$chrID[chrindex] # character strings
+            chr <- chrID[chrindex] # character strings
         }
         if(length(chr) == 0)
             stop("Must retain at least one chromosome.")
 
         to_sub <- c("probs", "draws", "map", "is_x_chr", "grid", "snpinfo") # draws is here, to also deal with sim_geno objects
         for(a in to_sub) {
-            if(a %in% names(x))
+            if(a %in% names(x)) {
                 x[[a]] <- x[[a]][chr]
+            }
         }
-        x$chrID <- chr
     }
 
+    if("probs" %in% names(x))
+        indID <- rownames(x$probs[[1]])
+    else if("draws" %in% names(x))
+        indID <- rownames(x$draws[[1]])
+    else stop("Neither probs no draws found.")
+
+    n_ind <- length(indID)
     if(!missing(ind) && !is.null(ind)) {
         if(is.logical(ind)) {
-            if(length(ind) != length(x$indID)) {
+            if(length(ind) != n_ind) {
                 stop("length(ind) [", length(ind), "] != no. ind in x [",
-                     length(x$indID), "]")
+                     n_ind, "]")
             }
-            ind <- x$indID[ind] # convert to character strings
+            ind <- indID[ind] # convert to character strings
         }
         else if(is.numeric(ind)) {
-            if(any(ind < 1 || ind > length(x$indID)))
-                stop("Numeric ind out of allowed range [1 - ", length(x$indID), "]")
-            ind <- x$indID[ind] # convert to character strings
+            if(any(ind < 1 || ind > n_ind))
+                stop("Numeric ind out of allowed range [1 - ", n_ind, "]")
+            ind <- indID[ind] # convert to character strings
         }
         else {
-            indindex <- match(ind, x$indID)
+            indindex <- match(ind, indID)
             if(any(is.na(indindex))) {
                 stop("Some individuals not found: ",
                      paste(ind[is.na(indindex)], collapse=", "))
             }
-            ind <- x$indID[indindex]
+            ind <- indID[indindex]
         }
         if(length(ind) == 0)
             stop("Must retain at least one individual.")
 
-        to_sub_mat <- c("probs", "draws") # draws is here to also handle sim_geno objects
-        for(a in to_sub_mat) {
+        for(a in c("probs", "draws")) {
             if(a %in% names(x)) {
-                for(i in x$chrID)
+                for(i in names(x$map)) # loop over chromosomes
                     x[[a]][[i]] <- x[[a]][[i]][ind,,,drop=FALSE]
             }
         }
         if(!is.null(x$cross_info))
             x$cross_info <- x$cross_info[ind, , drop=FALSE]
-        x$indID <- ind
     }
 
     x

--- a/man/calc_genoprob.Rd
+++ b/man/calc_genoprob.Rd
@@ -49,8 +49,6 @@ A list containing the following
 \item \code{grid} - A list of logical vectors, indicating which
     positions correspond to a grid of markers/pseudomarkers. (may be
     absent)
-\item \code{indID} - Vector of character strings with individual IDs
-\item \code{chrID} - Vector of character strings with chromosome IDs
 \item \code{crosstype} - The cross type of the input \code{cross}.
 \item \code{is_x_chr} - Logical vector indicating whether chromosomes
     are to be treated as the X chromosome or not, from input \code{cross}.

--- a/man/sim_geno.Rd
+++ b/man/sim_geno.Rd
@@ -51,8 +51,6 @@ individuals x positions x draws.
 \item \code{grid} - A list of logical vectors, indicating which
     positions correspond to a grid of markers/pseudomarkers. (may be
     absent)
-\item \code{indID} - Vector of character strings with individual IDs
-\item \code{chrID} - Vector of character strings with chromosome IDs
 \item \code{crosstype} - The cross type of the input \code{cross}.
 \item \code{is_x_chr} - Logical vector indicating whether chromosomes
     are to be treated as the X chromosome or not, from input \code{cross}.

--- a/tests/testthat/test-calc_kinship.R
+++ b/tests/testthat/test-calc_kinship.R
@@ -17,7 +17,7 @@ test_that("calc_kinship works for RIL", {
 
     # check unnormalized
     sim_unnorm <- calc_kinship(probs, normalize=FALSE)
-    n_ind <- length(probs$indID)
+    n_ind <- nrow(probs$probs[[1]])
     expect_equal(sim_unnorm *(n_ind-1)/(sum(diag(sim_unnorm)) - sum(sim_unnorm)/n_ind),
                  sim)
 
@@ -28,7 +28,7 @@ test_that("calc_kinship works for RIL", {
         pairs <- c(pairs, list(sample(n_ind, 2), sample(n_ind, 2)))
     expected <- rep(0, length(pairs))
     tot_pos <- 0
-    for(i in seq(along=probs$chrID)) {
+    for(i in seq(along=probs$probs)) {
         for(k in seq(along=pairs))
             expected[k] <- expected[k] + sum(probs_sub$prob[[i]][pairs[[k]][1],,] * probs_sub$prob[[i]][pairs[[k]][2],,])
         tot_pos <- tot_pos + dim(probs_sub$prob[[i]])[3]
@@ -71,7 +71,7 @@ test_that("calc_kinship (unnormalized) works for F2", {
 
     # check a few values
     set.seed(54028069)
-    n_ind <- length(probs$indID)
+    n_ind <- nrow(probs$probs[[1]])
     pairs <- list(c(1,2))
     for(i in 1:5)
         pairs <- c(pairs, list(sample(n_ind, 2), sample(n_ind, 2)))
@@ -129,13 +129,13 @@ test_that("calc_kinship (unnormalized) works for F2", {
 
     # check a few values
     set.seed(54028069)
-    n_ind <- length(probs$indID)
+    n_ind <- nrow(probs$probs[[1]])
     pairs <- list(c(1,2))
     for(i in 1:5)
         pairs <- c(pairs, list(sample(n_ind, 2), sample(n_ind, 2)))
     expected <- rep(0, length(pairs))
     tot_pos <- 0
-    for(i in seq(along=probs_sub$chrID)) {
+    for(i in seq(along=probs_sub$probs)) {
         for(k in seq(along=pairs)) {
             prob_1 <- probs_sub$prob[[i]][pairs[[k]][1],,,drop=FALSE]
             prob_2 <- probs_sub$prob[[i]][pairs[[k]][2],,,drop=FALSE]
@@ -159,7 +159,7 @@ test_that("calc_kinship (unnormalized) works for F2", {
     # check a few values
     expected <- rep(0, length(pairs))
     tot_pos <- 0
-    for(i in seq(along=probs_sub$chrID)) {
+    for(i in seq(along=probs_sub$probs)) {
         for(k in seq(along=pairs)) {
             prob_1 <- probs_sub$prob[[i]][pairs[[k]][1],,,drop=FALSE]
             prob_2 <- probs_sub$prob[[i]][pairs[[k]][2],,,drop=FALSE]
@@ -193,18 +193,18 @@ test_that("calc_kinship (unnormalized) chr & loco work for F2", {
     expect_equal(sim_combchr, sim)
 
     # calculate results with one chromosome at a time
-    sim_alt <- vector("list", length(probs$chrID))
-    names(sim_alt) <- probs$chrID
-    for(i in probs$chrID)
+    sim_alt <- vector("list", length(probs$probs))
+    names(sim_alt) <- names(probs$probs)
+    for(i in names(probs$probs))
         sim_alt[[i]] <- calc_kinship(probs[,i], omit_x=FALSE, normalize=FALSE)
     expect_equal(sim_alt, sim_chr)
 
     # compare sim - sim_chr with sim_loco
-    sim_loco_alt <- vector("list", length(probs$chrID))
-    names(sim_loco_alt) <- probs$chrID
+    sim_loco_alt <- vector("list", length(probs$probs))
+    names(sim_loco_alt) <- names(probs$probs)
     is_x_chr <- probs$is_x_chr
     totpos <- attr(sim, "n_pos")
-    for(i in seq(along=probs$chrID)) {
+    for(i in seq(along=probs$probs)) {
         if(is_x_chr[i])
             sim_loco_alt[[i]] <- sim
         else {
@@ -236,10 +236,10 @@ test_that("calc_kinship (unnormalized) chr & loco work for F2, when including X"
     expect_equal(sim_combchr, sim)
 
     # compare sim - sim_chr with sim_loco
-    sim_loco_alt <- vector("list", length(probs$chrID))
-    names(sim_loco_alt) <- probs$chrID
+    sim_loco_alt <- vector("list", length(probs$probs))
+    names(sim_loco_alt) <- names(probs$probs)
     totpos <- attr(sim, "n_pos")
-    for(i in seq(along=probs$chrID)) {
+    for(i in seq(along=probs$probs)) {
         npos <- attr(sim_chr[[i]], "n_pos")
         sim_loco_alt[[i]] <- (sim*totpos - sim_chr[[i]]*npos)/(totpos-npos)
         attr(sim_loco_alt[[i]], "n_pos") <- totpos-npos

--- a/tests/testthat/test-genoprob_to_alleleprob.R
+++ b/tests/testthat/test-genoprob_to_alleleprob.R
@@ -9,7 +9,7 @@ test_that("genoprob_to_alleleprob works for RIL", {
     # expected result, hardly changed
     expected <- probs
     expected$alleleprobs <- TRUE
-    for(i in seq(along=probs$chrID))
+    for(i in seq(along=probs$probs))
         colnames(expected$probs[[i]]) <- c("L", "C")
 
     expect_equal(allele_probs, expected)
@@ -45,7 +45,7 @@ test_that("genoprob_to_alleleprob works for F2", {
 
     expected <- probs
     is_x_chr <- probs$is_x_chr
-    for(i in seq(along=probs$chrID)) # loop over chromosomes
+    for(i in seq(along=probs$probs)) # loop over chromosomes
         expected$probs[[i]] <- f2_geno2alle(probs$probs[[i]], is_x_chr[i])
     expected$alleleprobs <- TRUE
 

--- a/tests/testthat/test-probs_to_grid.R
+++ b/tests/testthat/test-probs_to_grid.R
@@ -19,7 +19,7 @@ test_that("probs_to_grid works", {
 
     # test results
     expected <- probs
-    for(i in seq(along=probs$chrID)) {
+    for(i in seq(along=probs$probs)) {
         grid <- probs$grid[[i]]
         expected$probs[[i]] <- probs$probs[[i]][,,grid,drop=FALSE]
 

--- a/tests/testthat/test-subset.R
+++ b/tests/testthat/test-subset.R
@@ -70,7 +70,6 @@ test_that("subset.calc_genoprob works", {
     expected$probs <- pr$probs["X"]
     expected$is_x_chr <- pr$is_x_chr["X"]
     expected$map <- pr$map["X"]
-    expected$chrID <- "X"
     expected$grid <- pr$grid["X"]
 
     expect_equal(prsub, expected)
@@ -80,7 +79,6 @@ test_that("subset.calc_genoprob works", {
 
     expected$probs[["X"]] <- expected$probs[["X"]][ind,,,drop=FALSE]
     expected$cross_info <- expected$cross_info[ind,,drop=FALSE]
-    expected$indID <- ind
 
     expect_equal(prsub, expected)
 
@@ -98,7 +96,6 @@ test_that("subset.sim_geno works", {
     expected$draws <- dr$draws["X"]
     expected$is_x_chr <- dr$is_x_chr["X"]
     expected$map <- dr$map["X"]
-    expected$chrID <- "X"
     expected$grid <- dr$grid["X"]
 
     expect_equal(drsub, expected)
@@ -108,7 +105,6 @@ test_that("subset.sim_geno works", {
 
     expected$draws[["X"]] <- expected$draws[["X"]][ind,,,drop=FALSE]
     expected$cross_info <- expected$cross_info[ind,,drop=FALSE]
-    expected$indID <- ind
 
     expect_equal(drsub, expected)
 


### PR DESCRIPTION
- They are redundant information and the ease doesn't make up for the extra work.
- (Also, got a bit confused with pushing and pulling.)
