### PR TITLE
Implement faster versions of calc_genoprob and sim_geno

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: qtl2geno
-Version: 0.4-11
-Date: 2016-05-16
+Version: 0.4-12
+Date: 2016-05-23
 Title: Treatment of Marker Genotypes for QTL Experiments
 Description: Functions to calculate QTL genotype probabilities, impute
     QTL genotypes, and estimate genetic maps. Part of R/qtl2, a

--- a/R/RcppExports.R
+++ b/R/RcppExports.R
@@ -73,6 +73,10 @@ nalleles <- function(crosstype) {
     .Call('qtl2geno_sim_geno', PACKAGE = 'qtl2geno', crosstype, genotypes, founder_geno, is_X_chr, is_female, cross_info, rec_frac, marker_index, error_prob, n_draws)
 }
 
+.sim_geno2 <- function(crosstype, genotypes, founder_geno, is_X_chr, is_female, cross_info, rec_frac, marker_index, error_prob, n_draws) {
+    .Call('qtl2geno_sim_geno2', PACKAGE = 'qtl2geno', crosstype, genotypes, founder_geno, is_X_chr, is_female, cross_info, rec_frac, marker_index, error_prob, n_draws)
+}
+
 addlog <- function(a, b) {
     .Call('qtl2geno_addlog', PACKAGE = 'qtl2geno', a, b)
 }

--- a/R/RcppExports.R
+++ b/R/RcppExports.R
@@ -113,3 +113,11 @@ need_founder_geno <- function(crosstype) {
     .Call('qtl2geno_need_founder_geno', PACKAGE = 'qtl2geno', crosstype)
 }
 
+test_emitmatrix <- function(crosstype, error_prob, founder_geno, is_x_chr, is_female, cross_info) {
+    .Call('qtl2geno_test_emitmatrix', PACKAGE = 'qtl2geno', crosstype, error_prob, founder_geno, is_x_chr, is_female, cross_info)
+}
+
+test_stepmatrix <- function(crosstype, rec_frac, is_x_chr, is_female, cross_info) {
+    .Call('qtl2geno_test_stepmatrix', PACKAGE = 'qtl2geno', crosstype, rec_frac, is_x_chr, is_female, cross_info)
+}
+

--- a/R/RcppExports.R
+++ b/R/RcppExports.R
@@ -61,6 +61,10 @@ nalleles <- function(crosstype) {
     .Call('qtl2geno_calc_genoprob', PACKAGE = 'qtl2geno', crosstype, genotypes, founder_geno, is_X_chr, is_female, cross_info, rec_frac, marker_index, error_prob)
 }
 
+.calc_genoprob2 <- function(crosstype, genotypes, founder_geno, is_X_chr, is_female, cross_info, rec_frac, marker_index, error_prob) {
+    .Call('qtl2geno_calc_genoprob2', PACKAGE = 'qtl2geno', crosstype, genotypes, founder_geno, is_X_chr, is_female, cross_info, rec_frac, marker_index, error_prob)
+}
+
 .est_map <- function(crosstype, genotypes, founder_geno, is_X_chr, is_female, cross_info, rec_frac, error_prob, max_iterations, tol, verbose) {
     .Call('qtl2geno_est_map', PACKAGE = 'qtl2geno', crosstype, genotypes, founder_geno, is_X_chr, is_female, cross_info, rec_frac, error_prob, max_iterations, tol, verbose)
 }
@@ -119,5 +123,9 @@ test_emitmatrix <- function(crosstype, error_prob, founder_geno, is_x_chr, is_fe
 
 test_stepmatrix <- function(crosstype, rec_frac, is_x_chr, is_female, cross_info) {
     .Call('qtl2geno_test_stepmatrix', PACKAGE = 'qtl2geno', crosstype, rec_frac, is_x_chr, is_female, cross_info)
+}
+
+test_initvector <- function(crosstype, is_x_chr, is_female, cross_info) {
+    .Call('qtl2geno_test_initvector', PACKAGE = 'qtl2geno', crosstype, is_x_chr, is_female, cross_info)
 }
 

--- a/R/calc_genoprob.R
+++ b/R/calc_genoprob.R
@@ -21,6 +21,10 @@
 #' @param error_prob Assumed genotyping error probability
 #' @param map_function Character string indicating the map function to
 #' use to convert genetic distances to recombination fractions.
+#' @param lowmem If \code{FALSE}, split individuals into groups with
+#' common sex and crossinfo and then precalculate the transition
+#' matrices for a chromosome; potentially a lot faster but using more
+#' memory.
 #' @param quiet If \code{FALSE}, print progress messages.
 #' @param cores Number of CPU cores to use, for parallel calculations.
 #' (If \code{0}, use \code{\link[parallel]{detectCores}}.)
@@ -84,7 +88,7 @@
 calc_genoprob <-
 function(cross, step=0, off_end=0, stepwidth=c("fixed", "max"), pseudomarker_map=NULL,
          error_prob=1e-4, map_function=c("haldane", "kosambi", "c-f", "morgan"),
-         quiet=TRUE, cores=1)
+         lowmem=TRUE, quiet=TRUE, cores=1)
 {
     # check inputs
     if(!is.cross2(cross))
@@ -93,6 +97,10 @@ function(cross, step=0, off_end=0, stepwidth=c("fixed", "max"), pseudomarker_map
         stop("error_prob must be > 0")
     map_function <- match.arg(map_function)
     stepwidth <- match.arg(stepwidth)
+
+    if(!lowmem) # use other version
+        return(calc_genoprob2(cross, step, off_end, stepwidth, pseudomarker_map,
+                              error_prob, map_function, quiet, cores))
 
     # set up cluster; set quiet=TRUE if multi-core
     cores <- setup_cluster(cores, quiet)

--- a/R/calc_genoprob.R
+++ b/R/calc_genoprob.R
@@ -88,7 +88,7 @@
 calc_genoprob <-
 function(cross, step=0, off_end=0, stepwidth=c("fixed", "max"), pseudomarker_map=NULL,
          error_prob=1e-4, map_function=c("haldane", "kosambi", "c-f", "morgan"),
-         lowmem=TRUE, quiet=TRUE, cores=1)
+         lowmem=FALSE, quiet=TRUE, cores=1)
 {
     # check inputs
     if(!is.cross2(cross))

--- a/R/calc_genoprob.R
+++ b/R/calc_genoprob.R
@@ -99,8 +99,9 @@ function(cross, step=0, off_end=0, stepwidth=c("fixed", "max"), pseudomarker_map
     stepwidth <- match.arg(stepwidth)
 
     if(!lowmem) # use other version
-        return(calc_genoprob2(cross, step, off_end, stepwidth, pseudomarker_map,
-                              error_prob, map_function, quiet, cores))
+        return(calc_genoprob2(cross=cross, step=step, off_end=off_end, stepwidth=stepwidth,
+                              pseudomarker_map=pseudomarker_map, error_prob=error_prob,
+                              map_function=map_function, quiet=quiet, cores=cores))
 
     # set up cluster; set quiet=TRUE if multi-core
     cores <- setup_cluster(cores, quiet)

--- a/R/calc_genoprob2.R
+++ b/R/calc_genoprob2.R
@@ -1,0 +1,129 @@
+# calc_genoprob2
+# Calculate conditional genotype probabilities
+# this version pre-calculates init, step, and emit (attempting to be faster for DO)
+#
+# Same input and output as calc_genoprob()
+calc_genoprob2 <-
+function(cross, step=0, off_end=0, stepwidth=c("fixed", "max"), pseudomarker_map=NULL,
+         error_prob=1e-4, map_function=c("haldane", "kosambi", "c-f", "morgan"),
+         quiet=TRUE, cores=1)
+{
+    # check inputs
+    if(!is.cross2(cross))
+        stop('Input cross must have class "cross2"')
+    if(error_prob < 0)
+        stop("error_prob must be > 0")
+    map_function <- match.arg(map_function)
+    stepwidth <- match.arg(stepwidth)
+
+    # set up cluster; set quiet=TRUE if multi-core
+    cores <- setup_cluster(cores, quiet)
+    if(!quiet && n_cores(cores)>1) {
+        message(" - Using ", n_cores(cores), " cores")
+        quiet <- TRUE # make the rest quiet
+    }
+
+    # construct map at which to do the calculations
+    # tolerance for matching marker and pseudomarker positions
+    tol <- ifelse(step==0 || step>1, 0.01, step/100)
+    # create the combined marker/pseudomarker map
+    map <- insert_pseudomarkers(cross$gmap, step, off_end, stepwidth,
+                                pseudomarker_map, tol)
+    index <- map$index
+    grid <- map$grid
+    map <- map$map
+
+    probs <- vector("list", length(map))
+    rf <- map2rf(map, map_function)
+
+    # deal with missing information
+    ind <- rownames(cross$geno[[1]])
+    chrnames <- names(cross$geno)
+    is_x_chr <- handle_null_isxchr(cross$is_x_chr, chrnames)
+    cross$is_female <- handle_null_isfemale(cross$is_female, ind)
+    cross$cross_info <- handle_null_isfemale(cross$cross_info, ind)
+
+    founder_geno <- cross$founder_geno
+    if(is.null(founder_geno))
+        founder_geno <- create_empty_founder_geno(cross$geno)
+
+    by_group_func <- function(i) {
+        pr <- .calc_genoprob2(cross$crosstype, t(cross$geno[[chr]][group[[i]],,drop=FALSE]),
+                              founder_geno[[chr]], cross$is_x_chr[chr], cross$is_female[group[[i]][1]],
+                              cross$cross_info[group[[i]][1],], rf[[chr]], index[[chr]],
+                              error_prob)
+        aperm(pr, c(2,1,3))
+    }
+
+    # split individuals into groups with common sex and cross_info
+    sex_crossinfo <- paste(cross$is_female, apply(cross$cross_info, 1, paste, collapse=":"), sep=":")
+    group <- split(seq(along=sex_crossinfo), sex_crossinfo)
+    names(group) <- NULL
+    nc <- n_cores(cores)
+    while(nc > length(group)) { # successively split biggest group in half until there are as many groups as cores
+        mx <- which.max(sapply(group, length))
+        g <- group[[mx]]
+        group <- c(group, list(g[seq(1, length(g), by=2)]))
+        group[[mx]] <- g[seq(2, length(g), by=2)]
+    }
+    groupindex <- seq(along=group)
+
+    probs <- vector("list", length(cross$geno))
+    for(chr in seq(along=cross$geno)) {
+        if(!quiet) message("Chr ", names(cross$geno)[chr])
+
+        if(n_cores(cores) == 1) { # no parallel processing
+            # calculations in one group
+            temp <- lapply(groupindex, by_group_func)
+        }
+        else {
+            # calculations in parallel
+            temp <- cluster_lapply(cores, groupindex, by_group_func)
+
+        }
+        # paste them back together
+        d <- vapply(temp, dim, rep(0,3))
+        nr <- sum(d[1,])
+        probs[[chr]] <- array(dim=c(nr, d[2,1], d[3,1]))
+        for(i in groupindex)
+            probs[[chr]][group[[i]],,] <- temp[[i]]
+
+        # genotype names
+        alleles <- cross$alleles
+        if(is.null(alleles)) # no alleles saved; use caps
+            alleles <- LETTERS[1:ncol(probs[[chr]])]
+        gnames <- geno_names(cross$crosstype,
+                             alleles,
+                             cross$is_x_chr[chr])
+        if(length(gnames) != ncol(probs[[chr]])) {
+            warning("genotype names has length (", length(gnames),
+                    ") != genoprob dim (", ncol(probs[[chr]]), ")")
+            gnames <- NULL
+        }
+
+        dimnames(probs[[chr]]) <- list(rownames(cross$geno[[chr]]),
+                                       gnames,
+                                       names(map[[chr]]))
+
+    }
+
+    names(probs) <- names(cross$gmap)
+    result <- list(probs=probs,
+                   map=map,
+                   crosstype=cross$crosstype,
+                   is_x_chr=cross$is_x_chr,
+                   sex=cross$sex,
+                   cross_info=cross$cross_info,
+                   alleles=cross$alleles,
+                   alleleprobs=FALSE,
+                   step=step,
+                   off_end=off_end,
+                   stepwidth=stepwidth,
+                   error_prob=error_prob,
+                   map_function=map_function)
+    result$grid <- grid # include only if not NULL
+
+    class(result) <- c("calc_genoprob", "list")
+
+    result
+}

--- a/R/calc_genoprob2.R
+++ b/R/calc_genoprob2.R
@@ -60,7 +60,7 @@ function(cross, step=0, off_end=0, stepwidth=c("fixed", "max"), pseudomarker_map
     group <- split(seq(along=sex_crossinfo), sex_crossinfo)
     names(group) <- NULL
     nc <- n_cores(cores)
-    while(nc > length(group)) { # successively split biggest group in half until there are as many groups as cores
+    while(nc > length(group) && max(sapply(group, length)) > 1) { # successively split biggest group in half until there are as many groups as cores
         mx <- which.max(sapply(group, length))
         g <- group[[mx]]
         group <- c(group, list(g[seq(1, length(g), by=2)]))

--- a/R/calc_kinship.R
+++ b/R/calc_kinship.R
@@ -212,7 +212,7 @@ kinship_bychr2loco <-
     kinship[allchr]
 }
 
-# normlize kinship as in ****
+# normalize kinship as in Kostem and Eskin (2013) Am J Hum Genet 92:558-564
 # (suggested by Petr Simecek)
 normalize_kinship <-
     function(kinship)

--- a/R/sim_geno.R
+++ b/R/sim_geno.R
@@ -75,7 +75,7 @@
 sim_geno <-
 function(cross, n_draws=1, step=0, off_end=0, stepwidth=c("fixed", "max"), pseudomarker_map=NULL,
          error_prob=1e-4, map_function=c("haldane", "kosambi", "c-f", "morgan"),
-         lowmem=TRUE, quiet=TRUE, cores=1)
+         lowmem=FALSE, quiet=TRUE, cores=1)
 {
     # check inputs
     if(!is.cross2(cross))

--- a/R/sim_geno.R
+++ b/R/sim_geno.R
@@ -23,6 +23,10 @@
 #' @param error_prob Assumed genotyping error probability
 #' @param map_function Character string indicating the map function to
 #' use to convert genetic distances to recombination fractions.
+#' @param lowmem If \code{FALSE}, split individuals into groups with
+#' common sex and crossinfo and then precalculate the transition
+#' matrices for a chromosome; potentially a lot faster but using more
+#' memory.
 #' @param quiet If \code{FALSE}, print progress messages.
 #' @param cores Number of CPU cores to use, for parallel calculations.
 #' (If \code{0}, use \code{\link[parallel]{detectCores}}.)
@@ -71,7 +75,7 @@
 sim_geno <-
 function(cross, n_draws=1, step=0, off_end=0, stepwidth=c("fixed", "max"), pseudomarker_map=NULL,
          error_prob=1e-4, map_function=c("haldane", "kosambi", "c-f", "morgan"),
-         quiet=TRUE, cores=1)
+         lowmem=TRUE, quiet=TRUE, cores=1)
 {
     # check inputs
     if(!is.cross2(cross))
@@ -80,6 +84,12 @@ function(cross, n_draws=1, step=0, off_end=0, stepwidth=c("fixed", "max"), pseud
         stop("error_prob must be > 0")
     map_function <- match.arg(map_function)
     stepwidth <- match.arg(stepwidth)
+
+    if(!lowmem)
+        return(sim_geno2(cross=cross, n_draws=n_draws, step=step, off_end=off_end,
+                         stepwidth=stepwidth, pseudomarker_map=pseudomarker_map,
+                         error_prob=error_prob, map_function=map_function, quiet=quiet,
+                         cores=cores))
 
     # set up cluster; make quiet=FALSE if cores>1
     cores <- setup_cluster(cores)

--- a/R/sim_geno2.R
+++ b/R/sim_geno2.R
@@ -60,7 +60,7 @@ function(cross, n_draws=1, step=0, off_end=0, stepwidth=c("fixed", "max"), pseud
     group <- split(seq(along=sex_crossinfo), sex_crossinfo)
     names(group) <- NULL
     nc <- n_cores(cores)
-    while(nc > length(group)) { # successively split biggest group in half until there are as many groups as cores
+    while(nc > length(group) && max(sapply(group, length)) > 1) { # successively split biggest group in half until there are as many groups as cores
         mx <- which.max(sapply(group, length))
         g <- group[[mx]]
         group <- c(group, list(g[seq(1, length(g), by=2)]))

--- a/R/sim_geno2.R
+++ b/R/sim_geno2.R
@@ -1,0 +1,114 @@
+# sim_geno2
+# Simulate genotypes given observed marker data
+# this version pre-calculates init, step, and emit (attempting to be faster for DO)
+#
+# Same input and output as sim_geno()
+sim_geno2 <-
+function(cross, n_draws=1, step=0, off_end=0, stepwidth=c("fixed", "max"), pseudomarker_map=NULL,
+         error_prob=1e-4, map_function=c("haldane", "kosambi", "c-f", "morgan"),
+         quiet=TRUE, cores=1)
+{
+    # check inputs
+    if(!is.cross2(cross))
+        stop('Input cross must have class "cross2"')
+    if(error_prob < 0)
+        stop("error_prob must be > 0")
+    map_function <- match.arg(map_function)
+    stepwidth <- match.arg(stepwidth)
+
+    # set up cluster; make quiet=FALSE if cores>1
+    cores <- setup_cluster(cores)
+    if(!quiet && n_cores(cores) > 1) {
+        message(" - Using ", n_cores(cores), " cores")
+        quiet <- TRUE # no more messages
+    }
+
+    # construct map at which to do the calculations
+    # tolerance for matching marker and pseudomarker positions
+    tol <- ifelse(step==0 || step>1, 0.01, step/100)
+    # create the combined marker/pseudomarker map
+    map <- insert_pseudomarkers(cross$gmap, step, off_end, stepwidth,
+                                pseudomarker_map, tol)
+    index <- map$index
+    grid <- map$grid
+    map <- map$map
+
+    probs <- vector("list", length(map))
+    rf <- map2rf(map, map_function)
+
+    # deal with missing information
+    ind <- rownames(cross$geno[[1]])
+    chrnames <- names(cross$geno)
+    is_x_chr <- handle_null_isxchr(cross$is_x_chr, chrnames)
+    cross$is_female <- handle_null_isfemale(cross$is_female, ind)
+    cross$cross_info <- handle_null_isfemale(cross$cross_info, ind)
+
+    founder_geno <- cross$founder_geno
+    if(is.null(founder_geno))
+        founder_geno <- create_empty_founder_geno(cross$geno)
+
+    by_group_func <- function(i) {
+        dr <- .sim_geno2(cross$crosstype, t(cross$geno[[chr]][group[[i]],,drop=FALSE]),
+                         founder_geno[[chr]], cross$is_x_chr[chr], cross$is_female[group[[i]][1]],
+                         cross$cross_info[group[[i]][1],], rf[[chr]], index[[chr]],
+                         error_prob, n_draws)
+        aperm(dr, c(3,1,2))
+    }
+
+    # split individuals into groups with common sex and cross_info
+    sex_crossinfo <- paste(cross$is_female, apply(cross$cross_info, 1, paste, collapse=":"), sep=":")
+    group <- split(seq(along=sex_crossinfo), sex_crossinfo)
+    names(group) <- NULL
+    nc <- n_cores(cores)
+    while(nc > length(group)) { # successively split biggest group in half until there are as many groups as cores
+        mx <- which.max(sapply(group, length))
+        g <- group[[mx]]
+        group <- c(group, list(g[seq(1, length(g), by=2)]))
+        group[[mx]] <- g[seq(2, length(g), by=2)]
+    }
+    groupindex <- seq(along=group)
+
+    draws <- vector("list", length(cross$geno))
+    names(draws) <- names(cross$geno)
+    for(chr in seq(along=cross$geno)) {
+        if(!quiet) message("Chr ", names(cross$geno)[chr])
+
+        if(n_cores(cores)==1) { # no parallel processing
+            # calculations in one group
+            temp <- lapply(groupindex, by_group_func)
+        }
+        else {
+            # calculations in parallel
+            temp <- cluster_lapply(cores, groupindex, by_group_func)
+        }
+
+        # paste them back together
+        d <- vapply(temp, dim, rep(0,3))
+        nr <- sum(d[1,])
+        draws[[chr]] <- array(dim=c(nr, d[2,1], d[3,1]))
+        for(i in groupindex)
+            draws[[chr]][group[[i]],,] <- temp[[i]]
+
+        dimnames(draws[[chr]]) <- list(rownames(cross$geno[[chr]]),
+                                       names(map[[chr]]),
+                                       NULL)
+
+    }
+
+    names(draws) <- names(cross$gmap)
+    result <- list(draws=draws,
+                   map = map,
+                   crosstype = cross$crosstype,
+                   is_x_chr = cross$is_x_chr,
+                   sex = cross$sex,
+                   cross_info = cross$cross_info,
+                   step=step,
+                   off_end=off_end,
+                   stepwidth=stepwidth,
+                   error_prob=error_prob,
+                   map_function=map_function)
+    result$grid <- grid # include only if not NULL
+
+    class(result) <- c("sim_geno", "list")
+    result
+}

--- a/man/calc_genoprob.Rd
+++ b/man/calc_genoprob.Rd
@@ -6,7 +6,7 @@
 \usage{
 calc_genoprob(cross, step = 0, off_end = 0, stepwidth = c("fixed", "max"),
   pseudomarker_map = NULL, error_prob = 0.0001,
-  map_function = c("haldane", "kosambi", "c-f", "morgan"), lowmem = TRUE,
+  map_function = c("haldane", "kosambi", "c-f", "morgan"), lowmem = FALSE,
   quiet = TRUE, cores = 1)
 }
 \arguments{

--- a/man/calc_genoprob.Rd
+++ b/man/calc_genoprob.Rd
@@ -6,8 +6,8 @@
 \usage{
 calc_genoprob(cross, step = 0, off_end = 0, stepwidth = c("fixed", "max"),
   pseudomarker_map = NULL, error_prob = 0.0001,
-  map_function = c("haldane", "kosambi", "c-f", "morgan"), quiet = TRUE,
-  cores = 1)
+  map_function = c("haldane", "kosambi", "c-f", "morgan"), lowmem = TRUE,
+  quiet = TRUE, cores = 1)
 }
 \arguments{
 \item{cross}{Object of class \code{"cross2"}. For details, see the
@@ -32,6 +32,11 @@ ignored.}
 
 \item{map_function}{Character string indicating the map function to
 use to convert genetic distances to recombination fractions.}
+
+\item{lowmem}{If \code{FALSE}, split individuals into groups with
+common sex and crossinfo and then precalculate the transition
+matrices for a chromosome; potentially a lot faster but using more
+memory.}
 
 \item{quiet}{If \code{FALSE}, print progress messages.}
 

--- a/man/sim_geno.Rd
+++ b/man/sim_geno.Rd
@@ -7,7 +7,7 @@
 sim_geno(cross, n_draws = 1, step = 0, off_end = 0,
   stepwidth = c("fixed", "max"), pseudomarker_map = NULL,
   error_prob = 0.0001, map_function = c("haldane", "kosambi", "c-f",
-  "morgan"), quiet = TRUE, cores = 1)
+  "morgan"), lowmem = TRUE, quiet = TRUE, cores = 1)
 }
 \arguments{
 \item{cross}{Object of class \code{"cross2"}. For details, see the
@@ -34,6 +34,11 @@ ignored.}
 
 \item{map_function}{Character string indicating the map function to
 use to convert genetic distances to recombination fractions.}
+
+\item{lowmem}{If \code{FALSE}, split individuals into groups with
+common sex and crossinfo and then precalculate the transition
+matrices for a chromosome; potentially a lot faster but using more
+memory.}
 
 \item{quiet}{If \code{FALSE}, print progress messages.}
 

--- a/man/sim_geno.Rd
+++ b/man/sim_geno.Rd
@@ -7,7 +7,7 @@
 sim_geno(cross, n_draws = 1, step = 0, off_end = 0,
   stepwidth = c("fixed", "max"), pseudomarker_map = NULL,
   error_prob = 0.0001, map_function = c("haldane", "kosambi", "c-f",
-  "morgan"), lowmem = TRUE, quiet = TRUE, cores = 1)
+  "morgan"), lowmem = FALSE, quiet = TRUE, cores = 1)
 }
 \arguments{
 \item{cross}{Object of class \code{"cross2"}. For details, see the

--- a/src/RcppExports.cpp
+++ b/src/RcppExports.cpp
@@ -398,3 +398,34 @@ BEGIN_RCPP
     return __result;
 END_RCPP
 }
+// test_emitmatrix
+std::vector<NumericMatrix> test_emitmatrix(const String& crosstype, const double error_prob, const IntegerMatrix& founder_geno, const bool is_x_chr, const bool is_female, const IntegerVector& cross_info);
+RcppExport SEXP qtl2geno_test_emitmatrix(SEXP crosstypeSEXP, SEXP error_probSEXP, SEXP founder_genoSEXP, SEXP is_x_chrSEXP, SEXP is_femaleSEXP, SEXP cross_infoSEXP) {
+BEGIN_RCPP
+    Rcpp::RObject __result;
+    Rcpp::RNGScope __rngScope;
+    Rcpp::traits::input_parameter< const String& >::type crosstype(crosstypeSEXP);
+    Rcpp::traits::input_parameter< const double >::type error_prob(error_probSEXP);
+    Rcpp::traits::input_parameter< const IntegerMatrix& >::type founder_geno(founder_genoSEXP);
+    Rcpp::traits::input_parameter< const bool >::type is_x_chr(is_x_chrSEXP);
+    Rcpp::traits::input_parameter< const bool >::type is_female(is_femaleSEXP);
+    Rcpp::traits::input_parameter< const IntegerVector& >::type cross_info(cross_infoSEXP);
+    __result = Rcpp::wrap(test_emitmatrix(crosstype, error_prob, founder_geno, is_x_chr, is_female, cross_info));
+    return __result;
+END_RCPP
+}
+// test_stepmatrix
+std::vector<NumericMatrix> test_stepmatrix(const String& crosstype, const NumericVector& rec_frac, const bool is_x_chr, const bool is_female, const IntegerVector& cross_info);
+RcppExport SEXP qtl2geno_test_stepmatrix(SEXP crosstypeSEXP, SEXP rec_fracSEXP, SEXP is_x_chrSEXP, SEXP is_femaleSEXP, SEXP cross_infoSEXP) {
+BEGIN_RCPP
+    Rcpp::RObject __result;
+    Rcpp::RNGScope __rngScope;
+    Rcpp::traits::input_parameter< const String& >::type crosstype(crosstypeSEXP);
+    Rcpp::traits::input_parameter< const NumericVector& >::type rec_frac(rec_fracSEXP);
+    Rcpp::traits::input_parameter< const bool >::type is_x_chr(is_x_chrSEXP);
+    Rcpp::traits::input_parameter< const bool >::type is_female(is_femaleSEXP);
+    Rcpp::traits::input_parameter< const IntegerVector& >::type cross_info(cross_infoSEXP);
+    __result = Rcpp::wrap(test_stepmatrix(crosstype, rec_frac, is_x_chr, is_female, cross_info));
+    return __result;
+END_RCPP
+}

--- a/src/RcppExports.cpp
+++ b/src/RcppExports.cpp
@@ -201,6 +201,25 @@ BEGIN_RCPP
     return __result;
 END_RCPP
 }
+// calc_genoprob2
+NumericVector calc_genoprob2(const String& crosstype, const IntegerMatrix& genotypes, const IntegerMatrix& founder_geno, const bool is_X_chr, const bool is_female, const IntegerVector& cross_info, const NumericVector& rec_frac, const IntegerVector& marker_index, const double error_prob);
+RcppExport SEXP qtl2geno_calc_genoprob2(SEXP crosstypeSEXP, SEXP genotypesSEXP, SEXP founder_genoSEXP, SEXP is_X_chrSEXP, SEXP is_femaleSEXP, SEXP cross_infoSEXP, SEXP rec_fracSEXP, SEXP marker_indexSEXP, SEXP error_probSEXP) {
+BEGIN_RCPP
+    Rcpp::RObject __result;
+    Rcpp::RNGScope __rngScope;
+    Rcpp::traits::input_parameter< const String& >::type crosstype(crosstypeSEXP);
+    Rcpp::traits::input_parameter< const IntegerMatrix& >::type genotypes(genotypesSEXP);
+    Rcpp::traits::input_parameter< const IntegerMatrix& >::type founder_geno(founder_genoSEXP);
+    Rcpp::traits::input_parameter< const bool >::type is_X_chr(is_X_chrSEXP);
+    Rcpp::traits::input_parameter< const bool >::type is_female(is_femaleSEXP);
+    Rcpp::traits::input_parameter< const IntegerVector& >::type cross_info(cross_infoSEXP);
+    Rcpp::traits::input_parameter< const NumericVector& >::type rec_frac(rec_fracSEXP);
+    Rcpp::traits::input_parameter< const IntegerVector& >::type marker_index(marker_indexSEXP);
+    Rcpp::traits::input_parameter< const double >::type error_prob(error_probSEXP);
+    __result = Rcpp::wrap(calc_genoprob2(crosstype, genotypes, founder_geno, is_X_chr, is_female, cross_info, rec_frac, marker_index, error_prob));
+    return __result;
+END_RCPP
+}
 // est_map
 NumericVector est_map(const String& crosstype, const IntegerMatrix& genotypes, const IntegerMatrix& founder_geno, const bool is_X_chr, const LogicalVector& is_female, const IntegerMatrix& cross_info, const NumericVector& rec_frac, const double error_prob, const int max_iterations, const double tol, const bool verbose);
 RcppExport SEXP qtl2geno_est_map(SEXP crosstypeSEXP, SEXP genotypesSEXP, SEXP founder_genoSEXP, SEXP is_X_chrSEXP, SEXP is_femaleSEXP, SEXP cross_infoSEXP, SEXP rec_fracSEXP, SEXP error_probSEXP, SEXP max_iterationsSEXP, SEXP tolSEXP, SEXP verboseSEXP) {
@@ -426,6 +445,20 @@ BEGIN_RCPP
     Rcpp::traits::input_parameter< const bool >::type is_female(is_femaleSEXP);
     Rcpp::traits::input_parameter< const IntegerVector& >::type cross_info(cross_infoSEXP);
     __result = Rcpp::wrap(test_stepmatrix(crosstype, rec_frac, is_x_chr, is_female, cross_info));
+    return __result;
+END_RCPP
+}
+// test_initvector
+NumericVector test_initvector(const String& crosstype, const bool is_x_chr, const bool is_female, const IntegerVector& cross_info);
+RcppExport SEXP qtl2geno_test_initvector(SEXP crosstypeSEXP, SEXP is_x_chrSEXP, SEXP is_femaleSEXP, SEXP cross_infoSEXP) {
+BEGIN_RCPP
+    Rcpp::RObject __result;
+    Rcpp::RNGScope __rngScope;
+    Rcpp::traits::input_parameter< const String& >::type crosstype(crosstypeSEXP);
+    Rcpp::traits::input_parameter< const bool >::type is_x_chr(is_x_chrSEXP);
+    Rcpp::traits::input_parameter< const bool >::type is_female(is_femaleSEXP);
+    Rcpp::traits::input_parameter< const IntegerVector& >::type cross_info(cross_infoSEXP);
+    __result = Rcpp::wrap(test_initvector(crosstype, is_x_chr, is_female, cross_info));
     return __result;
 END_RCPP
 }

--- a/src/RcppExports.cpp
+++ b/src/RcppExports.cpp
@@ -261,6 +261,26 @@ BEGIN_RCPP
     return __result;
 END_RCPP
 }
+// sim_geno2
+IntegerVector sim_geno2(const String& crosstype, const IntegerMatrix& genotypes, const IntegerMatrix& founder_geno, const bool is_X_chr, const bool is_female, const IntegerVector& cross_info, const NumericVector& rec_frac, const IntegerVector& marker_index, const double error_prob, const int n_draws);
+RcppExport SEXP qtl2geno_sim_geno2(SEXP crosstypeSEXP, SEXP genotypesSEXP, SEXP founder_genoSEXP, SEXP is_X_chrSEXP, SEXP is_femaleSEXP, SEXP cross_infoSEXP, SEXP rec_fracSEXP, SEXP marker_indexSEXP, SEXP error_probSEXP, SEXP n_drawsSEXP) {
+BEGIN_RCPP
+    Rcpp::RObject __result;
+    Rcpp::RNGScope __rngScope;
+    Rcpp::traits::input_parameter< const String& >::type crosstype(crosstypeSEXP);
+    Rcpp::traits::input_parameter< const IntegerMatrix& >::type genotypes(genotypesSEXP);
+    Rcpp::traits::input_parameter< const IntegerMatrix& >::type founder_geno(founder_genoSEXP);
+    Rcpp::traits::input_parameter< const bool >::type is_X_chr(is_X_chrSEXP);
+    Rcpp::traits::input_parameter< const bool >::type is_female(is_femaleSEXP);
+    Rcpp::traits::input_parameter< const IntegerVector& >::type cross_info(cross_infoSEXP);
+    Rcpp::traits::input_parameter< const NumericVector& >::type rec_frac(rec_fracSEXP);
+    Rcpp::traits::input_parameter< const IntegerVector& >::type marker_index(marker_indexSEXP);
+    Rcpp::traits::input_parameter< const double >::type error_prob(error_probSEXP);
+    Rcpp::traits::input_parameter< const int >::type n_draws(n_drawsSEXP);
+    __result = Rcpp::wrap(sim_geno2(crosstype, genotypes, founder_geno, is_X_chr, is_female, cross_info, rec_frac, marker_index, error_prob, n_draws));
+    return __result;
+END_RCPP
+}
 // addlog
 double addlog(const double a, const double b);
 RcppExport SEXP qtl2geno_addlog(SEXP aSEXP, SEXP bSEXP) {

--- a/src/cross.h
+++ b/src/cross.h
@@ -282,7 +282,7 @@ public:
         Rcpp::IntegerVector gen = possible_gen(is_x_chr, is_female, cross_info);
         const unsigned int n_gen = gen.size();
 
-        Rcpp::NumericMatrix result(n_gen);
+        Rcpp::NumericVector result(n_gen);
         for(unsigned int g=0; g<n_gen; g++) {
             result[g] = init(gen[g], is_x_chr, is_female, cross_info);
         }

--- a/src/cross.h
+++ b/src/cross.h
@@ -225,7 +225,7 @@ public:
 
     // calculate a vector of emission matrices
     virtual const std::vector<Rcpp::NumericMatrix> calc_emitmatrix(const double error_prob,
-                                                                   const Rcpp::IntegerMatrix& founder_geno,
+                                                                   const Rcpp::IntegerMatrix& founder_geno, // columns are markers, rows are founder lines
                                                                    const bool is_x_chr, const bool is_female,
                                                                    const Rcpp::IntegerVector& cross_info)
     {
@@ -233,7 +233,7 @@ public:
         const unsigned int n_true_gen = gen.size();
         const unsigned int n_obs_gen = 6;
 
-        const unsigned int n_markers = founder_geno.rows();
+        const unsigned int n_markers = founder_geno.cols();
 
         std::vector<Rcpp::NumericMatrix> result;
         for(unsigned int i=0; i<n_markers; i++) {
@@ -241,7 +241,7 @@ public:
             for(unsigned int obs_gen=0; obs_gen<n_obs_gen; obs_gen++) {
                 for(unsigned int true_gen=0; true_gen<n_true_gen; true_gen++) {
                     emitmatrix(obs_gen,true_gen) = emit(obs_gen, gen[true_gen], error_prob,
-                                                        founder_geno[i], is_x_chr, is_female, cross_info);
+                                                        founder_geno(_, i), is_x_chr, is_female, cross_info);
                 }
             }
             result.push_back(emitmatrix);
@@ -270,6 +270,21 @@ public:
                 }
             }
             result.push_back(stepmatrix);
+        }
+
+        return result;
+    }
+
+    // calculate init probabilities
+    virtual const Rcpp::NumericVector calc_initvector(const bool is_x_chr, const bool is_female,
+                                        const Rcpp::IntegerVector& cross_info)
+    {
+        Rcpp::IntegerVector gen = possible_gen(is_x_chr, is_female, cross_info);
+        const unsigned int n_gen = gen.size();
+
+        Rcpp::NumericMatrix result(n_gen);
+        for(unsigned int g=0; g<n_gen; g++) {
+            result[g] = init(gen[g], is_x_chr, is_female, cross_info);
         }
 
         return result;

--- a/src/cross.h
+++ b/src/cross.h
@@ -223,6 +223,58 @@ public:
     }
 
 
+    // calculate a vector of emission matrices
+    virtual const std::vector<Rcpp::NumericMatrix> calc_emitmatrix(const double error_prob,
+                                                                   const Rcpp::IntegerMatrix& founder_geno,
+                                                                   const bool is_x_chr, const bool is_female,
+                                                                   const Rcpp::IntegerVector& cross_info)
+    {
+        Rcpp::IntegerVector gen = possible_gen(is_x_chr, is_female, cross_info);
+        const unsigned int n_true_gen = gen.size();
+        const unsigned int n_obs_gen = 6;
+
+        const unsigned int n_markers = founder_geno.rows();
+
+        std::vector<Rcpp::NumericMatrix> result;
+        for(unsigned int i=0; i<n_markers; i++) {
+            Rcpp::NumericMatrix emitmatrix(n_obs_gen, n_true_gen);
+            for(unsigned int obs_gen=0; obs_gen<n_obs_gen; obs_gen++) {
+                for(unsigned int true_gen=0; true_gen<n_true_gen; true_gen++) {
+                    emitmatrix(obs_gen,true_gen) = emit(obs_gen, gen[true_gen], error_prob,
+                                                        founder_geno[i], is_x_chr, is_female, cross_info);
+                }
+            }
+            result.push_back(emitmatrix);
+        }
+
+        return result;
+    }
+
+    // calculate a vector of transition matrices
+    virtual const std::vector<Rcpp::NumericMatrix> calc_stepmatrix(const Rcpp::NumericVector rec_frac,
+                                                                   const bool is_x_chr, const bool is_female,
+                                                                   const Rcpp::IntegerVector& cross_info)
+    {
+        Rcpp::IntegerVector gen = possible_gen(is_x_chr, is_female, cross_info);
+        const unsigned int n_gen = gen.size();
+
+        const unsigned int n_intervals = rec_frac.size();
+
+        std::vector<Rcpp::NumericMatrix> result;
+        for(unsigned int i=0; i<n_intervals; i++) {
+            Rcpp::NumericMatrix stepmatrix(n_gen, n_gen);
+            for(unsigned int left=0; left<n_gen; left++) {
+                for(unsigned int right=0; right<n_gen; right++) {
+                    stepmatrix(left,right) = step(gen[left], gen[right], rec_frac[i],
+                                                  is_x_chr, is_female, cross_info);
+                }
+            }
+            result.push_back(stepmatrix);
+        }
+
+        return result;
+    }
+
 };
 
 #endif // CROSS_H

--- a/src/hmm_calcgenoprob2.cpp
+++ b/src/hmm_calcgenoprob2.cpp
@@ -39,6 +39,8 @@ NumericVector calc_genoprob2(const String& crosstype,
     }
     if(!cross->check_founder_geno_size(founder_geno, n_mar))
         throw std::range_error("founder_geno is not the right size");
+    if(founder_geno.cols() != n_mar)
+        throw std::range_error("founder_geno and genotypes have different numbers of markers");
     // end of checks
 
     int n_gen = cross->ngen(is_X_chr);

--- a/src/hmm_calcgenoprob2.cpp
+++ b/src/hmm_calcgenoprob2.cpp
@@ -1,0 +1,84 @@
+// calculate conditional genotype probabilities given multipoint marker data
+// (this version assumes constant is_female and cross_info and pre-calcs the step and emit matrices)
+
+#include "hmm_calcgenoprob2.h"
+#include <math.h>
+#include <Rcpp.h>
+#include "cross.h"
+#include "hmm_util.h"
+#include "hmm_forwback2.h"
+
+// calculate conditional genotype probabilities given multipoint marker data
+// [[Rcpp::export(".calc_genoprob2")]]
+NumericVector calc_genoprob2(const String& crosstype,
+                             const IntegerMatrix& genotypes, // columns are individuals, rows are markers
+                             const IntegerMatrix& founder_geno, // columns are markers, rows are founder lines
+                             const bool is_X_chr,
+                             const bool is_female, // same for all individuals
+                             const IntegerVector& cross_info, // same for all individuals
+                             const NumericVector& rec_frac,   // length nrow(genotypes)-1
+                             const IntegerVector& marker_index, // length nrow(genotypes)
+                             const double error_prob)
+{
+    int n_ind = genotypes.cols();
+    int n_pos = marker_index.size();
+    int n_mar = genotypes.rows();
+
+    QTLCross* cross = QTLCross::Create(crosstype);
+
+    // check inputs
+    if(rec_frac.size() != n_pos-1)
+        throw std::range_error("length(rec_frac) != length(marker_index)-1");
+
+    if(error_prob < 0.0 || error_prob > 1.0)
+        throw std::range_error("error_prob out of range");
+
+    for(int i=0; i<rec_frac.size(); i++) {
+        if(rec_frac[i] < 0 || rec_frac[i] > 0.5)
+            throw std::range_error("rec_frac must be >= 0 and <= 0.5");
+    }
+    if(!cross->check_founder_geno_size(founder_geno, n_mar))
+        throw std::range_error("founder_geno is not the right size");
+    // end of checks
+
+    int n_gen = cross->ngen(is_X_chr);
+    int matsize = n_gen*n_ind; // size of genotype x individual matrix
+    NumericVector genoprobs(matsize*n_pos);
+
+    NumericVector init_vector = cross->calc_initvector(is_X_chr, is_female, cross_info);
+    std::vector<NumericMatrix> emit_matrix = cross->calc_emitmatrix(error_prob, founder_geno,
+                                                                   is_X_chr, is_female, cross_info);
+    std::vector<NumericMatrix> step_matrix = cross->calc_stepmatrix(rec_frac, is_X_chr, is_female, cross_info);
+
+    for(int ind=0; ind<n_ind; ind++) {
+
+        Rcpp::checkUserInterrupt();  // check for ^C from user
+
+        // possible genotypes for this individual
+        IntegerVector poss_gen = cross->possible_gen(is_X_chr, is_female, cross_info);
+        int n_poss_gen = poss_gen.size();
+
+        // forward/backward equations
+        NumericMatrix alpha = forwardEquations2(genotypes(_,ind), init_vector, emit_matrix, step_matrix, marker_index, poss_gen);
+        NumericMatrix beta = backwardEquations2(genotypes(_,ind), init_vector, emit_matrix, step_matrix, marker_index, poss_gen);
+
+        // calculate genotype probabilities
+        for(int pos=0, matindex=n_gen*ind; pos<n_pos; pos++, matindex += matsize) {
+            int g = poss_gen[0]-1;
+            double sum_at_pos = genoprobs[matindex+g] = alpha(0,pos) + beta(0,pos);
+            for(int i=1; i<n_poss_gen; i++) {
+                int g = poss_gen[i]-1;
+                double val = genoprobs[matindex+g] = alpha(i,pos) + beta(i,pos);
+                sum_at_pos = addlog(sum_at_pos, val);
+            }
+            for(int i=0; i<n_poss_gen; i++) {
+                int g = poss_gen[i]-1;
+                genoprobs[matindex+g] = exp(genoprobs[matindex+g] - sum_at_pos);
+            }
+        }
+    } // loop over individuals
+
+    genoprobs.attr("dim") = Dimension(n_gen, n_ind, n_pos);
+    delete cross;
+    return genoprobs;
+}

--- a/src/hmm_calcgenoprob2.cpp
+++ b/src/hmm_calcgenoprob2.cpp
@@ -46,8 +46,10 @@ NumericVector calc_genoprob2(const String& crosstype,
     NumericVector genoprobs(matsize*n_pos);
 
     NumericVector init_vector = cross->calc_initvector(is_X_chr, is_female, cross_info);
+
     std::vector<NumericMatrix> emit_matrix = cross->calc_emitmatrix(error_prob, founder_geno,
                                                                    is_X_chr, is_female, cross_info);
+
     std::vector<NumericMatrix> step_matrix = cross->calc_stepmatrix(rec_frac, is_X_chr, is_female, cross_info);
 
     for(int ind=0; ind<n_ind; ind++) {

--- a/src/hmm_calcgenoprob2.h
+++ b/src/hmm_calcgenoprob2.h
@@ -1,0 +1,18 @@
+// calculate conditional genotype probabilities given multipoint marker data
+// (this version assumes constant is_female and cross_info and pre-calcs the step and emit matrices)
+#ifndef HMM_CALCGENOPROB2_H
+#define HMM_CALCGENOPROB2_H
+
+#include <Rcpp.h>
+
+Rcpp::NumericVector calc_genoprob2(const Rcpp::String& crosstype,
+                                   const Rcpp::IntegerMatrix& genotypes, // columns are individuals, rows are markers
+                                   const Rcpp::IntegerMatrix& founder_geno, // columns are markers, rows are founder lines
+                                   const bool is_X_chr,
+                                   const bool is_female, // same for all individuals
+                                   const Rcpp::IntegerVector& cross_info, // same for all individuals
+                                   const Rcpp::NumericVector& rec_frac,   // length nrow(genotypes)-1
+                                   const Rcpp::IntegerVector& marker_index, // length nrow(genotypes)
+                                   const double error_prob);
+
+#endif // HMM_CALCGENOPROB2_H

--- a/src/hmm_forwback2.cpp
+++ b/src/hmm_forwback2.cpp
@@ -25,7 +25,6 @@ NumericMatrix forwardEquations2(const IntegerVector& genotypes,
 
     // initialize alphas
     for(int i=0; i<n_gen; i++) {
-        int g = poss_gen[i];
         alpha(i,0) = init_vector[i];
         if(marker_index[0] >= 0)
             alpha(i,0) += emit_matrix[marker_index[0]](genotypes[marker_index[0]], i);

--- a/src/hmm_forwback2.cpp
+++ b/src/hmm_forwback2.cpp
@@ -1,0 +1,82 @@
+// forward-backward equations for HMM
+// (this version assumes constant is_female and cross_info and pre-calcs the step and emit matrices)
+
+#include "hmm_forwback2.h"
+#include <math.h>
+#include <Rcpp.h>
+#include "cross.h"
+#include "hmm_util.h"
+
+// forward equations
+NumericMatrix forwardEquations2(const IntegerVector& genotypes,
+                                const Rcpp::NumericVector& init_vector,
+                                const std::vector<Rcpp::NumericMatrix>& emit_matrix,
+                                const std::vector<Rcpp::NumericMatrix>& step_matrix,
+                                const IntegerVector& marker_index,
+                                const IntegerVector& poss_gen)
+{
+    int n_pos = marker_index.size();
+
+    // possible genotypes for this chromosome and individual
+    int n_gen = poss_gen.size();
+
+    // to contain ln Pr(G_i = g | marker data)
+    NumericMatrix alpha(n_gen, n_pos);
+
+    // initialize alphas
+    for(int i=0; i<n_gen; i++) {
+        int g = poss_gen[i];
+        alpha(i,0) = init_vector[i];
+        if(marker_index[0] >= 0)
+            alpha(i,0) += emit_matrix[0](genotypes[marker_index[0]], i);
+    }
+
+    for(int pos=1; pos<n_pos; pos++) {
+        for(int ir=0; ir<n_gen; ir++) {
+            alpha(ir,pos) = alpha(0, pos-1) + step_matrix[pos-1](0, ir);
+
+            for(int il=1; il<n_gen; il++)
+                alpha(ir,pos) = addlog(alpha(ir,pos), alpha(il,pos-1) + step_matrix[pos-1](il, ir));
+
+            if(marker_index[pos]>=0)
+                alpha(ir,pos) += emit_matrix[pos](genotypes[marker_index[pos]], ir);
+        }
+    }
+
+    return alpha;
+}
+
+
+
+// backward Equations
+NumericMatrix backwardEquations2(const IntegerVector& genotypes,
+                                 const Rcpp::NumericVector& init_vector,
+                                 const std::vector<Rcpp::NumericMatrix>& emit_matrix,
+                                 const std::vector<Rcpp::NumericMatrix>& step_matrix,
+                                 const IntegerVector& marker_index,
+                                 const IntegerVector& poss_gen)
+{
+    int n_pos = marker_index.size();
+
+    // possible genotypes for this chromosome and individual
+    int n_gen = poss_gen.size();
+
+    // to contain ln Pr(G_i = g | marker data)
+    NumericMatrix beta(n_gen, n_pos);
+
+    // backward equations
+    for(int pos = n_pos-2; pos >= 0; pos--) {
+        for(int il=0; il<n_gen; il++) {
+            for(int ir=0; ir<n_gen; ir++) {
+                double to_add = beta(ir,pos+1) + step_matrix[pos](il, ir);
+                if(marker_index[pos+1] >=0)
+                    to_add += emit_matrix[pos+1](genotypes[marker_index[pos+1]], ir);
+
+                if(ir==0) beta(il,pos) = to_add;
+                else beta(il,pos) = addlog(beta(il,pos), to_add);
+            }
+        }
+    }
+
+    return beta;
+}

--- a/src/hmm_forwback2.cpp
+++ b/src/hmm_forwback2.cpp
@@ -28,7 +28,7 @@ NumericMatrix forwardEquations2(const IntegerVector& genotypes,
         int g = poss_gen[i];
         alpha(i,0) = init_vector[i];
         if(marker_index[0] >= 0)
-            alpha(i,0) += emit_matrix[0](genotypes[marker_index[0]], i);
+            alpha(i,0) += emit_matrix[marker_index[0]](genotypes[marker_index[0]], i);
     }
 
     for(int pos=1; pos<n_pos; pos++) {
@@ -39,7 +39,7 @@ NumericMatrix forwardEquations2(const IntegerVector& genotypes,
                 alpha(ir,pos) = addlog(alpha(ir,pos), alpha(il,pos-1) + step_matrix[pos-1](il, ir));
 
             if(marker_index[pos]>=0)
-                alpha(ir,pos) += emit_matrix[pos](genotypes[marker_index[pos]], ir);
+                alpha(ir,pos) += emit_matrix[marker_index[pos]](genotypes[marker_index[pos]], ir);
         }
     }
 
@@ -70,7 +70,7 @@ NumericMatrix backwardEquations2(const IntegerVector& genotypes,
             for(int ir=0; ir<n_gen; ir++) {
                 double to_add = beta(ir,pos+1) + step_matrix[pos](il, ir);
                 if(marker_index[pos+1] >=0)
-                    to_add += emit_matrix[pos+1](genotypes[marker_index[pos+1]], ir);
+                    to_add += emit_matrix[marker_index[pos+1]](genotypes[marker_index[pos+1]], ir);
 
                 if(ir==0) beta(il,pos) = to_add;
                 else beta(il,pos) = addlog(beta(il,pos), to_add);

--- a/src/hmm_forwback2.h
+++ b/src/hmm_forwback2.h
@@ -1,0 +1,26 @@
+// forward-backward equations for HMM
+// (this version assumes constant is_female and cross_info and pre-calcs the step and emit matrices)
+#ifndef HMM_FORWBACK2_H
+#define HMM_FORWBACK2_H
+
+#include <Rcpp.h>
+#include "cross.h"
+
+// forward equations
+Rcpp::NumericMatrix forwardEquations2(const Rcpp::IntegerVector& genotypes,
+                                      const Rcpp::NumericVector& init_vector,
+                                      const std::vector<Rcpp::NumericMatrix>& emit_matrix,
+                                      const std::vector<Rcpp::NumericMatrix>& step_matrix,
+                                      const Rcpp::IntegerVector& marker_index,
+                                      const Rcpp::IntegerVector& poss_gen);
+
+
+// backward Equations
+Rcpp::NumericMatrix backwardEquations2(const Rcpp::IntegerVector& genotypes,
+                                       const Rcpp::NumericVector& init_vector,
+                                      const std::vector<Rcpp::NumericMatrix>& emit_matrix,
+                                      const std::vector<Rcpp::NumericMatrix>& step_matrix,
+                                      const Rcpp::IntegerVector& marker_index,
+                                      const Rcpp::IntegerVector& poss_gen);
+
+#endif // HMM_FORWBACK2_H

--- a/src/hmm_simgeno.cpp
+++ b/src/hmm_simgeno.cpp
@@ -69,8 +69,8 @@ IntegerVector sim_geno(const String& crosstype,
             // calculate first prob (on log scale)
             probs[0] = cross->init(poss_gen[0], is_X_chr, is_female[ind], cross_info(_,ind)) + beta(0,0);
             if(marker_index[0] >= 0)
-                probs[0] = cross->emit(genotypes(marker_index[0],ind), poss_gen[0], error_prob,
-                                       founder_geno(_, marker_index[0]), is_X_chr, is_female[ind], cross_info(_,ind));
+                probs[0] += cross->emit(genotypes(marker_index[0],ind), poss_gen[0], error_prob,
+                                        founder_geno(_, marker_index[0]), is_X_chr, is_female[ind], cross_info(_,ind));
             double sumprobs = probs[0]; // to contain log(sum(probs))
 
             // calculate rest of probs

--- a/src/hmm_simgeno2.cpp
+++ b/src/hmm_simgeno2.cpp
@@ -1,0 +1,117 @@
+// simulate genotypes given observed marker data
+// (this version assumes constant is_female and cross_info and pre-calcs the step and emit matrices)
+
+#include "hmm_simgeno2.h"
+#include <math.h>
+#include <Rcpp.h>
+#include "cross.h"
+#include "hmm_util.h"
+#include "hmm_forwback2.h"
+#include "random.h"
+
+// simulate genotypes given observed marker data
+// [[Rcpp::export(".sim_geno2")]]
+IntegerVector sim_geno2(const String& crosstype,
+                        const IntegerMatrix& genotypes, // columns are individuals, rows are markers
+                        const IntegerMatrix& founder_geno, // columns are markers, rows are founder lines
+                        const bool is_X_chr,
+                        const bool is_female, // same for all individuals
+                        const IntegerVector& cross_info, // same for all individuals
+                        const NumericVector& rec_frac,   // length nrow(genotypes)-1
+                        const IntegerVector& marker_index, // length nrow(genotypes)
+                        const double error_prob,
+                        const int n_draws) // number of imputations
+{
+    const int n_ind = genotypes.cols();
+    const int n_pos = marker_index.size();
+    const int n_mar = genotypes.rows();
+
+    QTLCross* cross = QTLCross::Create(crosstype);
+
+    // check inputs
+    if(rec_frac.size() != n_pos-1)
+        throw std::range_error("length(rec_frac) != length(marker_index)-1");
+
+    if(error_prob < 0.0 || error_prob > 1.0)
+        throw std::range_error("error_prob out of range");
+
+    for(int i=0; i<rec_frac.size(); i++) {
+        if(rec_frac[i] < 0 || rec_frac[i] > 0.5)
+            throw std::range_error("rec_frac must be >= 0 and <= 0.5");
+    }
+    if(!cross->check_founder_geno_size(founder_geno, n_mar))
+        throw std::range_error("founder_geno is not the right size");
+    // end of checks
+
+    const int mat_size = n_pos*n_draws;
+    IntegerVector draws(mat_size*n_ind); // output object
+
+    NumericVector init_vector = cross->calc_initvector(is_X_chr, is_female, cross_info);
+
+    std::vector<NumericMatrix> emit_matrix = cross->calc_emitmatrix(error_prob, founder_geno,
+                                                                   is_X_chr, is_female, cross_info);
+
+    std::vector<NumericMatrix> step_matrix = cross->calc_stepmatrix(rec_frac, is_X_chr, is_female, cross_info);
+
+    for(int ind=0; ind<n_ind; ind++) {
+
+        Rcpp::checkUserInterrupt();  // check for ^C from user
+
+        // possible genotypes for this individual
+        IntegerVector poss_gen = cross->possible_gen(is_X_chr, is_female, cross_info);
+        int n_poss_gen = poss_gen.size();
+        NumericVector probs(n_poss_gen);
+
+        // backward equations
+        NumericMatrix beta = backwardEquations2(genotypes(_,ind), init_vector, emit_matrix, step_matrix, marker_index, poss_gen);
+
+        // simulate genotypes
+        for(int draw=0; draw<n_draws; draw++) {
+            // first draw
+            // calculate first prob (on log scale)
+            probs[0] = init_vector[0];
+            if(marker_index[0] >= 0)
+                probs[0] += emit_matrix[marker_index[0]](genotypes(marker_index[0],ind), poss_gen[0]);
+            double sumprobs = probs[0]; // to contain log(sum(probs))
+
+            // calculate rest of probs
+            for(int g=1; g<n_poss_gen; g++) {
+                probs[g] = init_vector[g];
+                if(marker_index[0] >= 0)
+                    probs[g] += emit_matrix[marker_index[0]](genotypes(marker_index[0],ind), poss_gen[g]);
+                sumprobs = addlog(sumprobs, probs[g]);
+            }
+
+            // re-scale probs
+            for(int g=0; g<n_poss_gen; g++)
+                probs[g] = exp(probs[g] - sumprobs);
+
+            // make draw, returns a value from 1, 2, ..., n_poss_gen
+            int curgeno = sample_int(probs);
+            draws[draw*n_pos + ind*mat_size] = poss_gen[curgeno];
+
+            // move along chromosome
+            for(int pos=1; pos<n_pos; pos++) {
+
+                // calculate probs
+                for(int g=0; g<n_poss_gen; g++) {
+                    probs[g] = step_matrix[pos-1](poss_gen[curgeno], poss_gen[g]) +
+                        beta(g,pos) - beta(curgeno, pos-1);
+                    if(marker_index[pos] >= 0)
+                        probs[g] += emit_matrix[marker_index[pos]](genotypes(marker_index[pos],ind), poss_gen[g]);
+                    probs[g] = exp(probs[g]);
+                }
+
+                // make draw
+                curgeno = sample_int(probs);
+
+                draws[pos + draw*n_pos + ind*mat_size] = poss_gen[curgeno];
+
+            } // loop over positions
+        } // loop over draws
+    } // loop over individuals
+
+    draws.attr("dim") = Dimension(n_pos, n_draws, n_ind);
+    delete cross;
+    return draws;
+}

--- a/src/hmm_simgeno2.cpp
+++ b/src/hmm_simgeno2.cpp
@@ -49,7 +49,7 @@ IntegerVector sim_geno2(const String& crosstype,
     NumericVector init_vector = cross->calc_initvector(is_X_chr, is_female, cross_info);
 
     std::vector<NumericMatrix> emit_matrix = cross->calc_emitmatrix(error_prob, founder_geno,
-                                                                   is_X_chr, is_female, cross_info);
+                                                                    is_X_chr, is_female, cross_info);
 
     std::vector<NumericMatrix> step_matrix = cross->calc_stepmatrix(rec_frac, is_X_chr, is_female, cross_info);
 
@@ -69,16 +69,16 @@ IntegerVector sim_geno2(const String& crosstype,
         for(int draw=0; draw<n_draws; draw++) {
             // first draw
             // calculate first prob (on log scale)
-            probs[0] = init_vector[0];
+            probs[0] = init_vector[0] + beta(0,0);
             if(marker_index[0] >= 0)
-                probs[0] += emit_matrix[marker_index[0]](genotypes(marker_index[0],ind), poss_gen[0]);
+                probs[0] += emit_matrix[marker_index[0]](genotypes(marker_index[0],ind), 0);
             double sumprobs = probs[0]; // to contain log(sum(probs))
 
             // calculate rest of probs
             for(int g=1; g<n_poss_gen; g++) {
-                probs[g] = init_vector[g];
+                probs[g] = init_vector[g] + beta(g,0);
                 if(marker_index[0] >= 0)
-                    probs[g] += emit_matrix[marker_index[0]](genotypes(marker_index[0],ind), poss_gen[g]);
+                    probs[g] += emit_matrix[marker_index[0]](genotypes(marker_index[0],ind), g);
                 sumprobs = addlog(sumprobs, probs[g]);
             }
 
@@ -95,10 +95,9 @@ IntegerVector sim_geno2(const String& crosstype,
 
                 // calculate probs
                 for(int g=0; g<n_poss_gen; g++) {
-                    probs[g] = step_matrix[pos-1](poss_gen[curgeno], poss_gen[g]) +
-                        beta(g,pos) - beta(curgeno, pos-1);
+                    probs[g] = step_matrix[pos-1](curgeno, g) + beta(g,pos) - beta(curgeno, pos-1);
                     if(marker_index[pos] >= 0)
-                        probs[g] += emit_matrix[marker_index[pos]](genotypes(marker_index[pos],ind), poss_gen[g]);
+                        probs[g] += emit_matrix[marker_index[pos]](genotypes(marker_index[pos],ind), g);
                     probs[g] = exp(probs[g]);
                 }
 

--- a/src/hmm_simgeno2.cpp
+++ b/src/hmm_simgeno2.cpp
@@ -41,6 +41,8 @@ IntegerVector sim_geno2(const String& crosstype,
     }
     if(!cross->check_founder_geno_size(founder_geno, n_mar))
         throw std::range_error("founder_geno is not the right size");
+    if(founder_geno.cols() != n_mar)
+        throw std::range_error("founder_geno and genotypes have different numbers of markers");
     // end of checks
 
     const int mat_size = n_pos*n_draws;

--- a/src/hmm_simgeno2.h
+++ b/src/hmm_simgeno2.h
@@ -1,0 +1,21 @@
+// simulate genotypes given observed marker data
+// (this version assumes constant is_female and cross_info and pre-calcs the step and emit matrices)
+
+#ifndef HMM_SIMGENO2_H
+#define HMM_SIMGENO2_H
+
+#include <Rcpp.h>
+
+// simulate genotypes given observed marker data
+Rcpp::IntegerVector sim_geno2(const Rcpp::String& crosstype,
+                              const Rcpp::IntegerMatrix& genotypes, // columns are individuals, rows are markers
+                              const Rcpp::IntegerMatrix& founder_geno, // columns are markers, rows are founder lines
+                              const bool is_X_chr,
+                              const bool is_female, // same for all individuals
+                              const Rcpp::IntegerVector& cross_info, // same for all individuals
+                              const Rcpp::NumericVector& rec_frac,   // length nrow(genotypes)-1
+                              const Rcpp::IntegerVector& marker_index, // length nrow(genotypes)
+                              const double error_prob,
+                              const int n_draws); // number of imputations
+
+#endif // HMM_SIMGENO2_H

--- a/src/test_hmm.cpp
+++ b/src/test_hmm.cpp
@@ -127,7 +127,7 @@ std::vector<NumericMatrix> test_emitmatrix(const String& crosstype,
 }
 
 
-// test emit functions from R
+// test calculation of vector of transition matrices
 // [[Rcpp::export]]
 std::vector<NumericMatrix> test_stepmatrix(const String& crosstype,
                                            const NumericVector& rec_frac,
@@ -136,6 +136,19 @@ std::vector<NumericMatrix> test_stepmatrix(const String& crosstype,
     QTLCross* cross = QTLCross::Create(crosstype);
 
     std::vector<NumericMatrix> result = cross->calc_stepmatrix(rec_frac, is_x_chr, is_female, cross_info);
+    delete cross;
+    return result;
+}
+
+
+// test calculation of init vector
+// [[Rcpp::export]]
+NumericVector test_initvector(const String& crosstype,
+                              const bool is_x_chr, const bool is_female, const IntegerVector& cross_info)
+{
+    QTLCross* cross = QTLCross::Create(crosstype);
+
+    NumericVector result = cross->calc_initvector(is_x_chr, is_female, cross_info);
     delete cross;
     return result;
 }

--- a/src/test_hmm.cpp
+++ b/src/test_hmm.cpp
@@ -35,7 +35,7 @@ double test_emit(const String& crosstype,
 }
 
 
-// test emit functions from R
+// test step functions from R
 // [[Rcpp::export]]
 double test_step(const String& crosstype,
                  const int gen_left, const int gen_right, const double rec_frac,
@@ -108,6 +108,34 @@ bool need_founder_geno(const String& crosstype)
     QTLCross* cross = QTLCross::Create(crosstype);
 
     bool result = cross->need_founder_geno();
+    delete cross;
+    return result;
+}
+
+// test calculation of vector of emit matrices
+// [[Rcpp::export]]
+std::vector<NumericMatrix> test_emitmatrix(const String& crosstype,
+                                           const double error_prob,
+                                           const IntegerMatrix& founder_geno, const bool is_x_chr,
+                                           const bool is_female, const IntegerVector& cross_info)
+{
+    QTLCross* cross = QTLCross::Create(crosstype);
+
+    std::vector<Rcpp::NumericMatrix> result = cross->calc_emitmatrix(error_prob, founder_geno, is_x_chr, is_female, cross_info);
+    delete cross;
+    return result;
+}
+
+
+// test emit functions from R
+// [[Rcpp::export]]
+std::vector<NumericMatrix> test_stepmatrix(const String& crosstype,
+                                           const NumericVector& rec_frac,
+                                           const bool is_x_chr, const bool is_female, const IntegerVector& cross_info)
+{
+    QTLCross* cross = QTLCross::Create(crosstype);
+
+    std::vector<NumericMatrix> result = cross->calc_stepmatrix(rec_frac, is_x_chr, is_female, cross_info);
     delete cross;
     return result;
 }

--- a/src/test_hmm.h
+++ b/src/test_hmm.h
@@ -35,4 +35,15 @@ bool test_founder_geno(const Rcpp::String& crosstype, const Rcpp::IntegerMatrix&
 
 bool need_founder_geno(const Rcpp::String& crosstype);
 
+// test calculation of vector of emit matrices
+std::vector<Rcpp::NumericMatrix> test_emitmatrix(const Rcpp::String& crosstype,
+                                                 const double error_prob,
+                                                 const Rcpp::IntegerMatrix& founder_geno, const bool is_x_chr,
+                                                 const bool is_female, const Rcpp::IntegerVector& cross_info);
+
+// test emit functions from R
+std::vector<Rcpp::NumericMatrix> test_stepmatrix(const Rcpp::String& crosstype,
+                                                 const Rcpp::NumericVector& rec_frac,
+                                                 const bool is_x_chr, const bool is_female, const Rcpp::IntegerVector& cross_info);
+
 #endif // TEST_HMM_H

--- a/src/test_hmm.h
+++ b/src/test_hmm.h
@@ -41,9 +41,13 @@ std::vector<Rcpp::NumericMatrix> test_emitmatrix(const Rcpp::String& crosstype,
                                                  const Rcpp::IntegerMatrix& founder_geno, const bool is_x_chr,
                                                  const bool is_female, const Rcpp::IntegerVector& cross_info);
 
-// test emit functions from R
+// test calculation of vector of transition matrices
 std::vector<Rcpp::NumericMatrix> test_stepmatrix(const Rcpp::String& crosstype,
                                                  const Rcpp::NumericVector& rec_frac,
                                                  const bool is_x_chr, const bool is_female, const Rcpp::IntegerVector& cross_info);
+
+// test calculation of init vector
+Rcpp::NumericVector test_initvector(const Rcpp::String& crosstype,
+                                    const bool is_x_chr, const bool is_female, const Rcpp::IntegerVector& cross_info);
 
 #endif // TEST_HMM_H

--- a/tests/testthat/test-calcgenoprob2.R
+++ b/tests/testthat/test-calcgenoprob2.R
@@ -8,7 +8,7 @@ test_that("backcross autosome", {
     hyper <- hyper[chr,]
 
     hyper <- convert2cross2(hyper)
-    pr <- calc_genoprob(hyper, error_prob=0.002)
+    pr <- calc_genoprob(hyper, error_prob=0.002, lowmem=TRUE)
     pr2 <- calc_genoprob(hyper, error_prob=0.002, lowmem=FALSE)
 
     expect_equal(pr, pr2)
@@ -22,7 +22,7 @@ test_that("intercross autosome", {
     listeria <- listeria[chr,]
 
     listeria <- convert2cross2(listeria)
-    pr <- calc_genoprob(listeria, step=1, stepwidth="max", error_prob=0.01)
+    pr <- calc_genoprob(listeria, step=1, stepwidth="max", error_prob=0.01, lowmem=TRUE)
     pr2 <- calc_genoprob(listeria, step=1, stepwidth="max", error_prob=0.01, lowmem=FALSE)
 
     expect_equal(pr, pr2)
@@ -38,7 +38,7 @@ test_that("risib autosome", {
     class(hyper)[1] <- "risib"
 
     hyper <- convert2cross2(hyper)
-    pr <- calc_genoprob(hyper, step=1, stepwidth="max", error_prob=0.002)
+    pr <- calc_genoprob(hyper, step=1, stepwidth="max", error_prob=0.002, lowmem=TRUE)
     pr2 <- calc_genoprob(hyper, step=1, stepwidth="max", error_prob=0.002, lowmem=FALSE)
 
     expect_equal(pr, pr2)
@@ -53,7 +53,7 @@ test_that("riself autosome", {
     class(hyper)[1] <- "riself"
 
     hyper <- convert2cross2(hyper)
-    pr <- calc_genoprob(hyper, step=1, stepwidth="max", error_prob=0.002)
+    pr <- calc_genoprob(hyper, step=1, stepwidth="max", error_prob=0.002, lowmem=TRUE)
     pr2 <- calc_genoprob(hyper, step=1, stepwidth="max", error_prob=0.002, lowmem=FALSE)
 
     expect_equal(pr, pr2)
@@ -66,7 +66,7 @@ test_that("f2 X chr", {
     fake.f2 <- fake.f2["X",]
 
     fake.f2 <- convert2cross2(fake.f2)
-    pr <- calc_genoprob(fake.f2, step=1, stepwidth="max", error_prob=0.01)
+    pr <- calc_genoprob(fake.f2, step=1, stepwidth="max", error_prob=0.01, lowmem=TRUE)
     pr2 <- calc_genoprob(fake.f2, step=1, stepwidth="max", error_prob=0.01, lowmem=FALSE)
 
     expect_equal(pr, pr2)
@@ -81,7 +81,7 @@ test_that("bc X chr", {
     hyper$pheno$sex <- rep(c("female", "male"), nind(hyper)/2)
 
     hyper <- convert2cross2(hyper)
-    pr <- calc_genoprob(hyper, step=1, stepwidth="max", error_prob=0.02)
+    pr <- calc_genoprob(hyper, step=1, stepwidth="max", error_prob=0.02, lowmem=TRUE)
     pr2 <- calc_genoprob(hyper, step=1, stepwidth="max", error_prob=0.02, lowmem=FALSE)
 
     expect_equal(pr, pr2)
@@ -95,7 +95,7 @@ test_that("f2 X chr all males", {
     fake.f2$pheno$sex <- 1
 
     fake.f2 <- convert2cross2(fake.f2)
-    pr <- calc_genoprob(fake.f2, step=1, stepwidth="max", error_prob=0.02)
+    pr <- calc_genoprob(fake.f2, step=1, stepwidth="max", error_prob=0.02, lowmem=TRUE)
     pr2 <- calc_genoprob(fake.f2, step=1, stepwidth="max", error_prob=0.02, lowmem=FALSE)
 
     expect_equal(pr, pr2)
@@ -110,7 +110,7 @@ test_that("f2 X chr all females", {
     fake.f2$pheno$sex <- 0
 
     fake.f2 <- convert2cross2(fake.f2)
-    pr <- calc_genoprob(fake.f2, step=1, stepwidth="max", error_prob=0.02)
+    pr <- calc_genoprob(fake.f2, step=1, stepwidth="max", error_prob=0.02, lowmem=TRUE)
     pr2 <- calc_genoprob(fake.f2, step=1, stepwidth="max", error_prob=0.02, lowmem=FALSE)
 
     expect_equal(pr, pr2)
@@ -125,7 +125,7 @@ test_that("f2 X chr all females forw", {
     fake.f2$pheno$pgm <- 0
 
     fake.f2 <- convert2cross2(fake.f2)
-    pr <- calc_genoprob(fake.f2, step=1, stepwidth="max", error_prob=0.0001)
+    pr <- calc_genoprob(fake.f2, step=1, stepwidth="max", error_prob=0.0001, lowmem=TRUE)
     pr2 <- calc_genoprob(fake.f2, step=1, stepwidth="max", error_prob=0.0001, lowmem=FALSE)
 
     expect_equal(pr, pr2)
@@ -140,7 +140,7 @@ test_that("f2 X chr all females rev", {
     fake.f2$pheno$pgm <- 1
 
     fake.f2 <- convert2cross2(fake.f2)
-    pr <- calc_genoprob(fake.f2, step=1, stepwidth="max", error_prob=0.0001)
+    pr <- calc_genoprob(fake.f2, step=1, stepwidth="max", error_prob=0.0001, lowmem=TRUE)
     pr2 <- calc_genoprob(fake.f2, step=1, stepwidth="max", error_prob=0.0001, lowmem=FALSE)
 
     expect_equal(pr, pr2)
@@ -153,7 +153,7 @@ test_that("bc X chr all males", {
     hyper <- hyper["X",]
 
     hyper <- convert2cross2(hyper)
-    pr <- calc_genoprob(hyper, step=1, stepwidth="max", error_prob=0.02)
+    pr <- calc_genoprob(hyper, step=1, stepwidth="max", error_prob=0.02, lowmem=TRUE)
     pr2 <- calc_genoprob(hyper, step=1, stepwidth="max", error_prob=0.02, lowmem=FALSE)
 
     expect_equal(pr, pr2)
@@ -168,7 +168,7 @@ test_that("bc X chr all females", {
     hyper$pheno$sex <- "female"
 
     hyper <- convert2cross2(hyper)
-    pr <- calc_genoprob(hyper, step=1, stepwidth="max", error_prob=0.02)
+    pr <- calc_genoprob(hyper, step=1, stepwidth="max", error_prob=0.02, lowmem=TRUE)
     pr2 <- calc_genoprob(hyper, step=1, stepwidth="max", error_prob=0.02, lowmem=FALSE)
 
     expect_equal(pr, pr2)
@@ -183,7 +183,7 @@ test_that("doubled haploids", {
     class(hyper)[1] <- "dh"
 
     hyper <- convert2cross2(hyper)
-    pr <- calc_genoprob(hyper, step=1, stepwidth="max", error_prob=0.02)
+    pr <- calc_genoprob(hyper, step=1, stepwidth="max", error_prob=0.02, lowmem=TRUE)
     pr2 <- calc_genoprob(hyper, step=1, stepwidth="max", error_prob=0.02, lowmem=FALSE)
 
     expect_equal(pr, pr2)
@@ -199,7 +199,7 @@ test_that("haploids calc_genoprob", {
     class(hyper)[1] <- "haploid"
 
     hyper <- convert2cross2(hyper)
-    pr <- calc_genoprob(hyper, step=1, stepwidth="max", error_prob=0.02)
+    pr <- calc_genoprob(hyper, step=1, stepwidth="max", error_prob=0.02, lowmem=TRUE)
     pr2 <- calc_genoprob(hyper, step=1, stepwidth="max", error_prob=0.02, lowmem=FALSE)
 
     expect_equal(pr, pr2)
@@ -214,7 +214,7 @@ test_that("backcross autosome with markers at same location", {
     # put some markers at same location
     grav2$gmap[[1]][4] <- grav2$gmap[[1]][3]
 
-    pr <- calc_genoprob(grav2, err=0)
+    pr <- calc_genoprob(grav2, err=0, lowmem=TRUE)
     pr2 <- calc_genoprob(grav2, err=0, lowmem=FALSE)
 
     expect_true( all(!is.na(pr[[1]])) )
@@ -227,8 +227,8 @@ test_that("calc_genoprob works when multi-core", {
 
     data(hyper)
     hyper2 <- convert2cross2(hyper)
-    pr <- calc_genoprob(hyper2, error_prob=0.002)
-    pr_mc <- calc_genoprob(hyper2, error_prob=0.002, cores=4)
+    pr <- calc_genoprob(hyper2, error_prob=0.002, lowmem=TRUE)
+    pr_mc <- calc_genoprob(hyper2, error_prob=0.002, cores=4, lowmem=TRUE)
     expect_equal(pr_mc, pr)
 
     pr2 <- calc_genoprob(hyper2, error_prob=0.002, lowmem=FALSE)
@@ -238,8 +238,8 @@ test_that("calc_genoprob works when multi-core", {
 
     data(listeria)
     listeria2 <- convert2cross2(listeria)
-    pr <- calc_genoprob(listeria2, step=1, stepwidth="max", error_prob=0.01)
-    pr_mc <- calc_genoprob(listeria2, step=1, stepwidth="max", error_prob=0.01, cores=4)
+    pr <- calc_genoprob(listeria2, step=1, stepwidth="max", error_prob=0.01, lowmem=TRUE)
+    pr_mc <- calc_genoprob(listeria2, step=1, stepwidth="max", error_prob=0.01, cores=4, lowmem=TRUE)
     expect_equal(pr_mc, pr)
 
     pr2 <- calc_genoprob(listeria2, step=1, stepwidth="max", error_prob=0.01, lowmem=FALSE)

--- a/tests/testthat/test-calcgenoprob2.R
+++ b/tests/testthat/test-calcgenoprob2.R
@@ -1,0 +1,250 @@
+context("calc_genoprob2")
+suppressMessages(library(qtl))
+
+test_that("backcross autosome", {
+
+    data(hyper)
+    chr <- c(1, 3, 4, 17, 19)
+    hyper <- hyper[chr,]
+
+    hyper <- convert2cross2(hyper)
+    pr <- calc_genoprob(hyper, error_prob=0.002)
+    pr2 <- calc_genoprob(hyper, error_prob=0.002, lowmem=FALSE)
+
+    expect_equal(pr, pr2)
+
+})
+
+test_that("intercross autosome", {
+
+    data(listeria)
+    chr <- c(1, 4, 14, 18)
+    listeria <- listeria[chr,]
+
+    listeria <- convert2cross2(listeria)
+    pr <- calc_genoprob(listeria, step=1, stepwidth="max", error_prob=0.01)
+    pr2 <- calc_genoprob(listeria, step=1, stepwidth="max", error_prob=0.01, lowmem=FALSE)
+
+    expect_equal(pr, pr2)
+
+})
+
+
+test_that("risib autosome", {
+
+    data(hyper)
+    chr <- c(1, 3, 4, 17, 19)
+    hyper <- hyper[chr,]
+    class(hyper)[1] <- "risib"
+
+    hyper <- convert2cross2(hyper)
+    pr <- calc_genoprob(hyper, step=1, stepwidth="max", error_prob=0.002)
+    pr2 <- calc_genoprob(hyper, step=1, stepwidth="max", error_prob=0.002, lowmem=FALSE)
+
+    expect_equal(pr, pr2)
+
+})
+
+test_that("riself autosome", {
+
+    data(hyper)
+    chr <- c(1, 3, 4, 17, 19)
+    hyper <- hyper[chr,]
+    class(hyper)[1] <- "riself"
+
+    hyper <- convert2cross2(hyper)
+    pr <- calc_genoprob(hyper, step=1, stepwidth="max", error_prob=0.002)
+    pr2 <- calc_genoprob(hyper, step=1, stepwidth="max", error_prob=0.002, lowmem=FALSE)
+
+    expect_equal(pr, pr2)
+
+})
+
+test_that("f2 X chr", {
+
+    data(fake.f2)
+    fake.f2 <- fake.f2["X",]
+
+    fake.f2 <- convert2cross2(fake.f2)
+    pr <- calc_genoprob(fake.f2, step=1, stepwidth="max", error_prob=0.01)
+    pr2 <- calc_genoprob(fake.f2, step=1, stepwidth="max", error_prob=0.01, lowmem=FALSE)
+
+    expect_equal(pr, pr2)
+
+})
+
+test_that("bc X chr", {
+
+    data(hyper)
+    hyper <- hyper["X",]
+    # make it half female, half male
+    hyper$pheno$sex <- rep(c("female", "male"), nind(hyper)/2)
+
+    hyper <- convert2cross2(hyper)
+    pr <- calc_genoprob(hyper, step=1, stepwidth="max", error_prob=0.02)
+    pr2 <- calc_genoprob(hyper, step=1, stepwidth="max", error_prob=0.02, lowmem=FALSE)
+
+    expect_equal(pr, pr2)
+
+})
+
+test_that("f2 X chr all males", {
+
+    data(fake.f2)
+    fake.f2 <- fake.f2["X",]
+    fake.f2$pheno$sex <- 1
+
+    fake.f2 <- convert2cross2(fake.f2)
+    pr <- calc_genoprob(fake.f2, step=1, stepwidth="max", error_prob=0.02)
+    pr2 <- calc_genoprob(fake.f2, step=1, stepwidth="max", error_prob=0.02, lowmem=FALSE)
+
+    expect_equal(pr, pr2)
+
+})
+
+
+test_that("f2 X chr all females", {
+
+    data(fake.f2)
+    fake.f2 <- fake.f2["X",]
+    fake.f2$pheno$sex <- 0
+
+    fake.f2 <- convert2cross2(fake.f2)
+    pr <- calc_genoprob(fake.f2, step=1, stepwidth="max", error_prob=0.02)
+    pr2 <- calc_genoprob(fake.f2, step=1, stepwidth="max", error_prob=0.02, lowmem=FALSE)
+
+    expect_equal(pr, pr2)
+
+})
+
+test_that("f2 X chr all females forw", {
+
+    data(fake.f2)
+    fake.f2 <- fake.f2["X",]
+    fake.f2$pheno$sex <- 0
+    fake.f2$pheno$pgm <- 0
+
+    fake.f2 <- convert2cross2(fake.f2)
+    pr <- calc_genoprob(fake.f2, step=1, stepwidth="max", error_prob=0.0001)
+    pr2 <- calc_genoprob(fake.f2, step=1, stepwidth="max", error_prob=0.0001, lowmem=FALSE)
+
+    expect_equal(pr, pr2)
+
+})
+
+test_that("f2 X chr all females rev", {
+
+    data(fake.f2)
+    fake.f2 <- fake.f2["X",]
+    fake.f2$pheno$sex <- 0
+    fake.f2$pheno$pgm <- 1
+
+    fake.f2 <- convert2cross2(fake.f2)
+    pr <- calc_genoprob(fake.f2, step=1, stepwidth="max", error_prob=0.0001)
+    pr2 <- calc_genoprob(fake.f2, step=1, stepwidth="max", error_prob=0.0001, lowmem=FALSE)
+
+    expect_equal(pr, pr2)
+
+})
+
+test_that("bc X chr all males", {
+
+    data(hyper)
+    hyper <- hyper["X",]
+
+    hyper <- convert2cross2(hyper)
+    pr <- calc_genoprob(hyper, step=1, stepwidth="max", error_prob=0.02)
+    pr2 <- calc_genoprob(hyper, step=1, stepwidth="max", error_prob=0.02, lowmem=FALSE)
+
+    expect_equal(pr, pr2)
+
+})
+
+
+test_that("bc X chr all females", {
+
+    data(hyper)
+    hyper <- hyper["X",]
+    hyper$pheno$sex <- "female"
+
+    hyper <- convert2cross2(hyper)
+    pr <- calc_genoprob(hyper, step=1, stepwidth="max", error_prob=0.02)
+    pr2 <- calc_genoprob(hyper, step=1, stepwidth="max", error_prob=0.02, lowmem=FALSE)
+
+    expect_equal(pr, pr2)
+
+})
+
+test_that("doubled haploids", {
+
+    data(hyper)
+    hyper <- hyper[1,]
+    hyper$pheno <- hyper$pheno[,1,drop=FALSE]
+    class(hyper)[1] <- "dh"
+
+    hyper <- convert2cross2(hyper)
+    pr <- calc_genoprob(hyper, step=1, stepwidth="max", error_prob=0.02)
+    pr2 <- calc_genoprob(hyper, step=1, stepwidth="max", error_prob=0.02, lowmem=FALSE)
+
+    expect_equal(pr, pr2)
+
+})
+
+
+test_that("haploids calc_genoprob", {
+
+    data(hyper)
+    hyper <- hyper[2,]
+    hyper$pheno <- hyper$pheno[,1,drop=FALSE]
+    class(hyper)[1] <- "haploid"
+
+    hyper <- convert2cross2(hyper)
+    pr <- calc_genoprob(hyper, step=1, stepwidth="max", error_prob=0.02)
+    pr2 <- calc_genoprob(hyper, step=1, stepwidth="max", error_prob=0.02, lowmem=FALSE)
+
+    expect_equal(pr, pr2)
+
+})
+
+test_that("backcross autosome with markers at same location", {
+
+    grav2 <- read_cross2(system.file("extdata", "grav2.zip", package="qtl2geno"))
+    grav2 <- grav2[1:4,1]
+
+    # put some markers at same location
+    grav2$gmap[[1]][4] <- grav2$gmap[[1]][3]
+
+    pr <- calc_genoprob(grav2, err=0)
+    pr2 <- calc_genoprob(grav2, err=0, lowmem=FALSE)
+
+    expect_true( all(!is.na(pr[[1]])) )
+    expect_equal(pr, pr2)
+
+})
+
+test_that("calc_genoprob works when multi-core", {
+    if(isnt_karl()) skip("this test only run locally")
+
+    data(hyper)
+    hyper2 <- convert2cross2(hyper)
+    pr <- calc_genoprob(hyper2, error_prob=0.002)
+    pr_mc <- calc_genoprob(hyper2, error_prob=0.002, cores=4)
+    expect_equal(pr_mc, pr)
+
+    pr2 <- calc_genoprob(hyper2, error_prob=0.002, lowmem=FALSE)
+    expect_equal(pr2, pr)
+    pr2_mc <- calc_genoprob(hyper2, error_prob=0.002, cores=4, lowmem=FALSE)
+    expect_equal(pr2_mc, pr)
+
+    data(listeria)
+    listeria2 <- convert2cross2(listeria)
+    pr <- calc_genoprob(listeria2, step=1, stepwidth="max", error_prob=0.01)
+    pr_mc <- calc_genoprob(listeria2, step=1, stepwidth="max", error_prob=0.01, cores=4)
+    expect_equal(pr_mc, pr)
+
+    pr2 <- calc_genoprob(listeria2, step=1, stepwidth="max", error_prob=0.01, lowmem=FALSE)
+    expect_equal(pr2, pr)
+    pr2_mc <- calc_genoprob(listeria2, step=1, stepwidth="max", error_prob=0.01, cores=4, lowmem=FALSE)
+    expect_equal(pr2_mc, pr)
+
+})

--- a/tests/testthat/test-simgeno.R
+++ b/tests/testthat/test-simgeno.R
@@ -9,7 +9,7 @@ test_that("sim_geno riself", {
     grav2 <- read_cross2(system.file("extdata", "grav2.zip", package="qtl2geno"))
     dr <- sim_geno(grav2, n_draws=2, err=0.002, step=1)
 
-    expected <- structure(c(1L, 2L, 2L, 2L, 2L, 2L, 2L, 2L, 2L, 2L, 2L, 2L, 2L,
+    expected <- structure(c(2L, 2L, 2L, 2L, 2L, 2L, 2L, 2L, 2L, 2L, 2L, 2L, 2L,
                             2L, 2L, 2L, 2L, 2L, 2L, 2L, 2L, 2L, 2L, 2L, 2L, 2L, 2L, 2L, 2L,
                             2L, 2L, 2L, 2L, 2L, 1L, 1L, 1L, 1L, 1L, 1L, 1L, 1L, 1L, 1L, 1L,
                             1L, 1L, 1L, 1L, 1L, 1L, 1L, 1L, 1L, 1L, 1L, 1L, 1L, 1L, 2L, 2L,
@@ -17,7 +17,7 @@ test_that("sim_geno riself", {
                             2L, 2L, 2L, 2L, 2L, 2L, 2L, 2L, 2L, 2L, 2L, 2L, 2L, 2L, 2L, 2L,
                             2L, 2L, 2L, 2L, 2L, 2L, 2L, 2L, 2L, 2L, 2L, 2L, 2L, 2L, 2L, 2L,
                             2L, 2L, 2L, 2L, 2L, 2L, 2L, 2L, 2L, 2L, 2L, 2L, 2L, 2L, 2L, 2L,
-                            2L, 2L, 2L, 2L, 2L, 2L, 2L, 2L, 2L, 2L, 1L, 1L, 2L, 2L, 2L, 2L,
+                            2L, 2L, 2L, 2L, 2L, 2L, 2L, 2L, 2L, 2L, 2L, 2L, 2L, 2L, 2L, 2L,
                             2L, 2L, 2L, 2L, 2L, 2L, 2L, 2L, 2L, 2L, 2L, 2L, 2L, 2L, 2L, 2L,
                             2L, 2L, 2L, 2L, 2L, 2L, 2L, 2L, 2L, 2L, 2L, 2L, 2L, 2L, 2L, 2L,
                             2L, 2L, 2L, 2L, 1L, 1L, 1L, 1L, 1L, 1L, 1L, 1L, 1L, 1L, 1L, 1L,
@@ -64,14 +64,14 @@ test_that("sim_geno f2", {
     iron <- read_cross2(system.file("extdata", "iron.zip", package="qtl2geno"))
     dr <- sim_geno(iron, n_draws=2, err=0.002, step=1)
 
-    expected <- structure(c(6L, 4L, 6L, 4L, 6L, 4L, 6L, 4L, 6L, 4L, 6L, 4L, 6L,
-                            4L, 6L, 4L, 6L, 4L, 6L, 4L, 6L, 4L, 6L, 4L, 6L, 4L, 6L, 4L, 6L,
-                            4L, 6L, 4L, 6L, 4L, 6L, 4L, 6L, 4L, 6L, 4L, 6L, 4L, 6L, 4L, 6L,
-                            4L, 6L, 4L, 6L, 4L, 6L, 4L, 5L, 4L, 5L, 4L, 5L, 4L, 5L, 4L, 6L,
-                            4L, 6L, 4L, 6L, 4L, 6L, 4L, 6L, 4L, 6L, 4L, 6L, 4L, 6L, 4L, 6L,
-                            4L, 6L, 4L, 6L, 4L, 6L, 4L, 6L, 4L, 6L, 4L, 6L, 4L, 6L, 4L, 6L,
-                            4L, 6L, 4L, 6L, 4L, 6L, 4L, 6L, 4L, 6L, 4L, 6L, 4L, 6L, 4L, 6L,
-                            4L, 6L, 4L, 6L, 4L, 6L, 4L, 6L, 4L, 6L, 4L),
+    expected <- structure(c(5L, 4L, 5L, 4L, 5L, 4L, 5L, 4L, 5L, 4L, 5L, 4L, 5L,
+                            4L, 5L, 4L, 5L, 4L, 5L, 4L, 5L, 4L, 5L, 4L, 5L, 4L, 5L, 4L, 5L,
+                            4L, 5L, 4L, 5L, 4L, 5L, 4L, 5L, 4L, 5L, 4L, 5L, 4L, 5L, 4L, 5L,
+                            4L, 5L, 4L, 5L, 4L, 5L, 4L, 5L, 4L, 5L, 4L, 6L, 4L, 6L, 4L, 5L,
+                            4L, 5L, 4L, 5L, 4L, 5L, 4L, 5L, 4L, 5L, 4L, 5L, 4L, 5L, 4L, 5L,
+                            4L, 5L, 4L, 5L, 4L, 5L, 4L, 5L, 4L, 5L, 4L, 5L, 4L, 5L, 4L, 5L,
+                            4L, 5L, 4L, 5L, 4L, 5L, 4L, 5L, 4L, 5L, 4L, 5L, 4L, 5L, 4L, 5L,
+                            4L, 5L, 4L, 5L, 4L, 5L, 4L, 5L, 4L, 5L, 4L),
                           .Dim = c(2L, 30L, 2L),
                           .Dimnames = list(c("145", "146"), c("DXMit16", "cX.loc30.5",
                           "cX.loc31.5", "cX.loc32.5", "cX.loc33.5", "cX.loc34.5", "cX.loc35.5", "cX.loc36.5",

--- a/tests/testthat/test-simgeno.R
+++ b/tests/testthat/test-simgeno.R
@@ -113,3 +113,35 @@ test_that("sim_geno works when multi-core", {
     # re-set RNGkind
     RNGkind("Mersenne-Twister")
 })
+
+
+test_that("sim_geno riself gives same result for lowmem=TRUE and =FALSE", {
+
+    RNGkind("Mersenne-Twister")
+    grav2 <- read_cross2(system.file("extdata", "grav2.zip", package="qtl2geno"))
+    set.seed(20150918)
+    dr <- sim_geno(grav2, n_draws=2, err=0.002, step=1, lowmem=FALSE)
+    set.seed(20150918)
+    dr2 <- sim_geno(grav2, n_draws=2, err=0.002, step=1, lowmem=TRUE)
+
+    expect_equal(dr, dr2)
+
+})
+
+test_that("sim_geno f2 gives same result for lowmem=TRUE and =FALSE", {
+
+    RNGkind("Mersenne-Twister")
+    iron <- read_cross2(system.file("extdata", "iron.zip", package="qtl2geno"))
+
+    # order individuals to be sure that the get run in the same order
+    p <- paste(iron$is_female, apply(iron$cross_info, 1, paste, collapse=":"), sep=":")
+    iron <- iron[order(p),]
+
+    set.seed(20150918)
+    dr <- sim_geno(iron, n_draws=2, err=0.002, step=1, lowmem=FALSE)
+    set.seed(20150918)
+    dr2 <- sim_geno(iron, n_draws=2, err=0.002, step=1, lowmem=TRUE)
+
+    expect_equal(dr, dr2)
+
+})


### PR DESCRIPTION
- Split individuals into groups with common sex and cross_info
- Pre-calculate init, emit, and step probabilities
- The result is like 20x faster for the DO
- Also seems faster for backcross/intercross, so it's now the default
- Added an argument `lowmem` (the old version corresponds to `lowmem=TRUE`, but `lowmem=FALSE` is the default.
