### PR TITLE
calc_kinship: change default to normalize=FALSE

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: qtl2geno
-Version: 0.4-21
-Date: 2016-06-15
+Version: 0.4-22
+Date: 2016-06-16
 Title: Treatment of Marker Genotypes for QTL Experiments
 Description: Functions to calculate QTL genotype probabilities, impute
     QTL genotypes, and estimate genetic maps. Part of R/qtl2, a

--- a/R/calc_kinship.R
+++ b/R/calc_kinship.R
@@ -20,8 +20,7 @@
 #' \code{\link{genoprob_to_alleleprob}}); otherwise use the genotype
 #' probabilities.
 #' @param normalize If \code{TRUE}, divide the kinship matrix by a
-#' normalizing constant (see Details), to give better estimates of
-#' heritability.
+#' normalizing constant (see Details).
 #' @param quiet IF \code{FALSE}, print progress messages.
 #' @param cores Number of CPU cores to use, for parallel calculations.
 #' (If \code{0}, use \code{\link[parallel]{detectCores}}.)
@@ -48,7 +47,7 @@
 #' don't convert to allele probabilities but just use the original
 #' genotype probabilities.
 #'
-#' If \code{normalize=TRUE} (the default), we normalize the kinship matrix as in
+#' If \code{normalize=TRUE}, we normalize the kinship matrix as in
 #' equation 5 in Kang et al. (2010) Nat Genet
 #' 42:348-354. \href{http://www.ncbi.nlm.nih.gov/pubmed/20208533}{doi: 10.1038/ng.548}
 #'
@@ -64,7 +63,7 @@ calc_kinship <-
     function(probs, type=c("overall", "loco", "chr"),
              use_grid_only=TRUE, omit_x=FALSE,
              use_allele_probs=TRUE,
-             normalize=TRUE,
+             normalize=FALSE,
              quiet=TRUE, cores=1)
 {
     type <- match.arg(type)
@@ -212,7 +211,9 @@ kinship_bychr2loco <-
     kinship[allchr]
 }
 
-# normalize kinship as in Kostem and Eskin (2013) Am J Hum Genet 92:558-564
+# normalize kinship as in equation 5 in Kang et al. (2010) Nat Genet '
+# 42:348-354. http://www.ncbi.nlm.nih.gov/pubmed/20208533 (doi: 10.1038/ng.548)
+#
 # (suggested by Petr Simecek)
 normalize_kinship <-
     function(kinship)

--- a/man/calc_kinship.Rd
+++ b/man/calc_kinship.Rd
@@ -6,7 +6,7 @@
 \usage{
 calc_kinship(probs, type = c("overall", "loco", "chr"),
   use_grid_only = TRUE, omit_x = FALSE, use_allele_probs = TRUE,
-  normalize = TRUE, quiet = TRUE, cores = 1)
+  normalize = FALSE, quiet = TRUE, cores = 1)
 }
 \arguments{
 \item{probs}{Genotype probabilities, as calculated from
@@ -30,8 +30,7 @@ allele probabilities (that is, first run
 probabilities.}
 
 \item{normalize}{If \code{TRUE}, divide the kinship matrix by a
-normalizing constant (see Details), to give better estimates of
-heritability.}
+normalizing constant (see Details).}
 
 \item{quiet}{IF \code{FALSE}, print progress messages.}
 
@@ -66,7 +65,7 @@ For crosses with just two possible genotypes (e.g., backcross), we
 don't convert to allele probabilities but just use the original
 genotype probabilities.
 
-If \code{normalize=TRUE} (the default), we normalize the kinship matrix as in
+If \code{normalize=TRUE}, we normalize the kinship matrix as in
 equation 5 in Kang et al. (2010) Nat Genet
 42:348-354. \href{http://www.ncbi.nlm.nih.gov/pubmed/20208533}{doi: 10.1038/ng.548}
 }

--- a/tests/testthat/test-calc_kinship.R
+++ b/tests/testthat/test-calc_kinship.R
@@ -4,11 +4,11 @@ test_that("calc_kinship works for RIL", {
 
     grav2 <- read_cross2(system.file("extdata", "grav2.zip", package="qtl2geno"))
     probs <- calc_genoprob(grav2, step=1, error_prob=0.002)
-    sim <- calc_kinship(probs)
+    sim <- calc_kinship(probs, normalize=TRUE)
 
     # pre-subset to grid
     probs_sub <- probs_to_grid(probs)
-    sim2 <- calc_kinship(probs_sub)
+    sim2 <- calc_kinship(probs_sub, normalize=TRUE)
     expect_equal(sim, sim2)
 
     # row and colnames okay
@@ -286,13 +286,13 @@ test_that("calc_kinship normalization works", {
     iron <- read_cross2(system.file("extdata", "iron.zip", package="qtl2geno"))
     probs <- calc_genoprob(iron, step=1, error_prob=0.002)
 
-    sim <- calc_kinship(probs)
+    sim <- calc_kinship(probs, normalize=TRUE)
     sim_un <- calc_kinship(probs, normalize=FALSE)
     n <- nrow(sim)
     sim_n <- sim_un*(n-1)/(sum(diag(sim_un))-sum(sim_un)/n)
     expect_equal(sim_n, sim)
 
-    sim_chr <- calc_kinship(probs, "chr")
+    sim_chr <- calc_kinship(probs, "chr", normalize=TRUE)
     sim_chr_un <- calc_kinship(probs, "chr", normalize=FALSE)
     sim_chr_n <- lapply(sim_chr_un,
                         function(K) {
@@ -301,7 +301,7 @@ test_that("calc_kinship normalization works", {
                         })
     expect_equal(sim_chr_n, sim_chr)
 
-    sim_loco <- calc_kinship(probs, "loco")
+    sim_loco <- calc_kinship(probs, "loco", normalize=TRUE)
     sim_loco_un <- calc_kinship(probs, "loco", normalize=FALSE)
     sim_loco_n <- lapply(sim_loco_un,
                         function(K) {
@@ -310,7 +310,7 @@ test_that("calc_kinship normalization works", {
                         })
     expect_equal(sim_loco_n, sim_loco)
 
-    sim_loco <- calc_kinship(probs, "loco", omit_x=FALSE)
+    sim_loco <- calc_kinship(probs, "loco", omit_x=FALSE, normalize=TRUE)
     sim_loco_un <- calc_kinship(probs, "loco", omit_x=FALSE, normalize=FALSE)
     sim_loco_n <- lapply(sim_loco_un,
                         function(K) {
@@ -324,13 +324,13 @@ test_that("calc_kinship normalization works", {
     grav2 <- read_cross2(system.file("extdata", "grav2.zip", package="qtl2geno"))
     probs <- calc_genoprob(grav2, step=1, error_prob=0.002)
 
-    sim <- calc_kinship(probs)
+    sim <- calc_kinship(probs, normalize=TRUE)
     sim_un <- calc_kinship(probs, normalize=FALSE)
     n <- nrow(sim)
     sim_n <- sim_un*(n-1)/(sum(diag(sim_un))-sum(sim_un)/n)
     expect_equal(sim_n, sim)
 
-    sim_chr <- calc_kinship(probs, "chr")
+    sim_chr <- calc_kinship(probs, "chr", normalize=TRUE)
     sim_chr_un <- calc_kinship(probs, "chr", normalize=FALSE)
     sim_chr_n <- lapply(sim_chr_un,
                         function(K) {
@@ -339,7 +339,7 @@ test_that("calc_kinship normalization works", {
                         })
     expect_equal(sim_chr_n, sim_chr)
 
-    sim_loco <- calc_kinship(probs, "loco")
+    sim_loco <- calc_kinship(probs, "loco", normalize=TRUE)
     sim_loco_un <- calc_kinship(probs, "loco", normalize=FALSE)
     sim_loco_n <- lapply(sim_loco_un,
                         function(K) {


### PR DESCRIPTION
I'm inclined to think that the normalization of the kinship matrix is necessary when using SNP genotypes, where you need to deal with the IBS/IBD distinction, but that it isn't necessary for our case, where we're estimating the kinship matrix from haplotype probabilities, which concern IBD.

Note, though, that I think in [qtl2scan](https://github.com/rqtl/qtl2scan), we need to multiple the kinship matrix by 2 to get the right estimate of the heritability.
