### PR TITLE
Revise compare_geno to calculate proportions of matches

### DIFF
--- a/R/compare_geno.R
+++ b/R/compare_geno.R
@@ -137,7 +137,7 @@ summary_compare_geno <-
         object[is.na(object)] <- 0
     } else {
         p <- object
-        p[upper.tri(p)] <- cg[upper.tri(p)]/t(cg)[upper.tri(p)]
+        p[upper.tri(p)] <- object[upper.tri(p)]/t(object)[upper.tri(p)]
     }
     p[lower.tri(p)] <- t(p)[lower.tri(p)]
     diag(p) <- NA
@@ -245,7 +245,7 @@ max_compare_geno <-
         object[is.na(object)] <- 0
     } else {
         p <- object
-        p[upper.tri(p)] <- cg[upper.tri(p)]/t(cg)[upper.tri(p)]
+        p[upper.tri(p)] <- object[upper.tri(p)]/t(object)[upper.tri(p)]
     }
     p[lower.tri(p)] <- t(p)[lower.tri(p)]
     diag(p) <- NA

--- a/man/compare_geno.Rd
+++ b/man/compare_geno.Rd
@@ -4,13 +4,19 @@
 \alias{compare_geno}
 \title{Compare individuals' genotype data}
 \usage{
-compare_geno(cross, omit_x = FALSE, quiet = TRUE, cores = 1)
+compare_geno(cross, omit_x = FALSE, proportion = TRUE, quiet = TRUE,
+  cores = 1)
 }
 \arguments{
 \item{cross}{Object of class \code{"cross2"}. For details, see the
 \href{http://kbroman.org/qtl2/assets/vignettes/developer_guide.html}{R/qtl2 developer guide}.}
 
 \item{omit_x}{If TRUE, only use autosomal genotypes}
+
+\item{proportion}{If TRUE (the default), the upper triangle of the
+result contains the proportions of matching genotypes. If
+FALSE, the upper triangle contains counts of matching
+genotypes.}
 
 \item{quiet}{IF \code{FALSE}, print progress messages.}
 
@@ -21,10 +27,12 @@ produced by \code{\link[parallel]{makeCluster}}.}
 }
 \value{
 A square matrix; diagonal is number of observed genotypes
-for each individual; the upper triangle is the proprotion of matching
-genotypes for each pair; the lower triangle is the number of
-markers where both of a pair were genotyped. The object is
-given class \code{"compare_geno"}.
+for each individual. The values in the lower triangle are the
+numbers of markers where both of a pair were genotyped. The
+values in the upper triangle are either proportions or counts
+of matching genotypes for each pair (depending on whether
+\code{proportion=TRUE} or \code{=FALSE}). The object is given
+class \code{"compare_geno"}.
 }
 \description{
 Count the number of matching genotypes between all pairs of

--- a/man/compare_geno.Rd
+++ b/man/compare_geno.Rd
@@ -21,8 +21,8 @@ produced by \code{\link[parallel]{makeCluster}}.}
 }
 \value{
 A square matrix; diagonal is number of observed genotypes
-for each individual; upper triangle is the number of matching
-genotypes for each pair; lower triangle is the number of
+for each individual; the upper triangle is the proprotion of matching
+genotypes for each pair; the lower triangle is the number of
 markers where both of a pair were genotyped. The object is
 given class \code{"compare_geno"}.
 }

--- a/tests/testthat/test-compare_geno.R
+++ b/tests/testthat/test-compare_geno.R
@@ -6,21 +6,26 @@ test_that("compare_geno works", {
     iron <- iron[1:5, c(18:19,"X")]
 
     cg <- compare_geno(iron)
-    expected <- structure(c(6, 0, 6, 6, 0, 0, 0, 0, 0, 0, 2, 0, 6, 6, 0, 1, 0,
-                            4, 6, 0, 0, 0, 0, 0, 0), .Dim = c(5L, 5L),
+    expected <- structure(c(6, 0, 6, 6, 0, NA, 0, 0, 0, 0, 0.333333333333333,
+                            NA, 6, 6, 0, 0.166666666666667, NA, 0.666666666666667, 6, 0,
+                            NA, NA, NA, NA, 0), .Dim = c(5L, 5L),
                           .Dimnames = list(c("1", "2", "3", "4", "5"), c("1", "2", "3", "4", "5")),
                           class = c("compare_geno", "matrix"))
     expect_equal(cg, expected)
 
     cg_X <- compare_geno(iron[,"X"])
-    expectedX <- structure(c(2, 0, 2, 2, 0, 0, 0, 0, 0, 0, 0, 0, 2, 2, 0, 0, 0,
-                             2, 2, 0, 0, 0, 0, 0, 0), .Dim = c(5L, 5L),
+    expectedX <- structure(c(2, 0, 2, 2, 0, NA, 0, 0, 0, 0, 0, NA, 2, 2, 0, 0,
+                             NA, 1, 2, 0, NA, NA, NA, NA, 0), .Dim = c(5L, 5L),
                            .Dimnames = list(c("1", "2", "3", "4", "5"), c("1", "2", "3", "4", "5")),
                            class = c("compare_geno", "matrix"))
     expect_equal(cg_X, expectedX)
 
     cg_noX <- compare_geno(iron, omit_x=TRUE)
-    expect_equal(cg_noX, expected - expectedX)
+    expected_noX <- structure(c(4, 0, 4, 4, 0, NA, 0, 0, 0, 0, 0.5, NA, 4, 4, 0,
+                                0.25, NA, 0.5, 4, 0, NA, NA, NA, NA, 0), .Dim = c(5L, 5L),
+                              .Dimnames = list(c("1", "2", "3", "4", "5"), c("1", "2", "3", "4", "5")),
+                              class = c("compare_geno", "matrix"))
+    expect_equal(cg_noX, expected_noX)
 
     # test summary()
     expected <- structure(list(ind1 = character(0), ind2 = character(0), prop_match = numeric(0),

--- a/tests/testthat/test-compare_geno.R
+++ b/tests/testthat/test-compare_geno.R
@@ -10,6 +10,7 @@ test_that("compare_geno works", {
                             NA, 6, 6, 0, 0.166666666666667, NA, 0.666666666666667, 6, 0,
                             NA, NA, NA, NA, 0), .Dim = c(5L, 5L),
                           .Dimnames = list(c("1", "2", "3", "4", "5"), c("1", "2", "3", "4", "5")),
+                          proportion=TRUE,
                           class = c("compare_geno", "matrix"))
     expect_equal(cg, expected)
 
@@ -17,6 +18,7 @@ test_that("compare_geno works", {
     expectedX <- structure(c(2, 0, 2, 2, 0, NA, 0, 0, 0, 0, 0, NA, 2, 2, 0, 0,
                              NA, 1, 2, 0, NA, NA, NA, NA, 0), .Dim = c(5L, 5L),
                            .Dimnames = list(c("1", "2", "3", "4", "5"), c("1", "2", "3", "4", "5")),
+                           proportion=TRUE,
                            class = c("compare_geno", "matrix"))
     expect_equal(cg_X, expectedX)
 
@@ -24,8 +26,14 @@ test_that("compare_geno works", {
     expected_noX <- structure(c(4, 0, 4, 4, 0, NA, 0, 0, 0, 0, 0.5, NA, 4, 4, 0,
                                 0.25, NA, 0.5, 4, 0, NA, NA, NA, NA, 0), .Dim = c(5L, 5L),
                               .Dimnames = list(c("1", "2", "3", "4", "5"), c("1", "2", "3", "4", "5")),
+                              proportion=TRUE,
                               class = c("compare_geno", "matrix"))
     expect_equal(cg_noX, expected_noX)
+
+    # if proportion=FALSE, total is sum of X and autosomes
+    expect_equal(compare_geno(iron, proportion=FALSE),
+                 compare_geno(iron[,"X"], proportion=FALSE) +
+                 compare_geno(iron, omit_x=TRUE, proportion=FALSE))
 
     # test summary()
     expected <- structure(list(ind1 = character(0), ind2 = character(0), prop_match = numeric(0),

--- a/tests/testthat/test-compare_geno.R
+++ b/tests/testthat/test-compare_geno.R
@@ -55,6 +55,20 @@ test_that("compare_geno works", {
     attr(expected, "threshold") <- NULL
     expect_equal(max(cg), expected)
 
+    # summary and max should give the same results whether you use proportion=TRUE or FALSE
+    expect_equal(summary(compare_geno(iron, proportion=TRUE)),
+                 summary(compare_geno(iron, proportion=FALSE)))
+    expect_equal(summary(compare_geno(iron, proportion=TRUE), threshold=0.7),
+                 summary(compare_geno(iron, proportion=FALSE), threshold=0.7))
+    expect_equal(max(compare_geno(iron, proportion=TRUE)),
+                 max(compare_geno(iron, proportion=FALSE)))
+    expect_equal(summary(compare_geno(iron, omit_x=TRUE, proportion=TRUE)),
+                 summary(compare_geno(iron, omit_x=TRUE, proportion=FALSE)))
+    expect_equal(summary(compare_geno(iron, omit_x=TRUE, proportion=TRUE), threshold=0.7),
+                 summary(compare_geno(iron, omit_x=TRUE, proportion=FALSE), threshold=0.7))
+    expect_equal(max(compare_geno(iron, omit_x=TRUE, proportion=TRUE)),
+                 max(compare_geno(iron, omit_x=TRUE, proportion=FALSE)))
+
 })
 
 test_that("compare_geno works when multi-core", {


### PR DESCRIPTION
- Add an argument `proportion`; if `TRUE` (the default), the upper triangle of the result contains the proportions of matching genotypes, rather than counts. If `FALSE`, give counts as before.
- Add an attribute `proportion` that indicates what was used, for help in getting the counts back.
- (I figure that in plots and such, we're mostly interested in the proportions, and except for the 0/0 case, we can easily get the counts back.)