### PR TITLE
Implemented 4-, 8-, and 16-way RIL by selfing

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: qtl2geno
 Version: 0.5-14
-Date: 2017-04-05
+Date: 2017-04-06
 Title: Treatment of Marker Genotypes for QTL Experiments
 Description: Functions to calculate QTL genotype probabilities, impute
     QTL genotypes, and estimate genetic maps. Part of R/qtl2, a

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: qtl2geno
-Version: 0.5-13
-Date: 2017-04-04
+Version: 0.5-14
+Date: 2017-04-05
 Title: Treatment of Marker Genotypes for QTL Experiments
 Description: Functions to calculate QTL genotype probabilities, impute
     QTL genotypes, and estimate genetic maps. Part of R/qtl2, a

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: qtl2geno
 Version: 0.5-13
-Date: 2017-04-03
+Date: 2017-04-04
 Title: Treatment of Marker Genotypes for QTL Experiments
 Description: Functions to calculate QTL genotype probabilities, impute
     QTL genotypes, and estimate genetic maps. Part of R/qtl2, a

--- a/NEWS.md
+++ b/NEWS.md
@@ -6,6 +6,17 @@
   `"riself16"`, for multi-way MAGIC populations (multi-way RILs by
   selfing).
 
+## Bug fixes
+
+- Fixed problem in `read_cross2` in the case that data has a physical
+  map but not a genetic map.
+
+## Minor changes
+
+- Added argument 'overwrite' to `write_control_file`; if `TRUE`,
+  overwrite the file, if it's present. (Previously, you were always
+  forced to first remove it.)
+
 
 ## qtl2geno 0.5-13 (2017-04-03)
 

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,3 +1,12 @@
+## qtl2geno 0.5-14 (2017-04-05)
+
+### New features
+
+- Implemented new cross types `"riself4"`, `"riself8"`, and
+  `"riself16"`, for multi-way MAGIC populations (multi-way RILs by
+  selfing).
+
+
 ## qtl2geno 0.5-13 (2017-04-03)
 
 ### New features

--- a/R/RcppExports.R
+++ b/R/RcppExports.R
@@ -49,6 +49,10 @@ mpp_geno_names <- function(alleles, is_x_chr) {
     .Call('qtl2geno_mpp_geno_names', PACKAGE = 'qtl2geno', alleles, is_x_chr)
 }
 
+reverse_index_founders <- function(cross_info) {
+    .Call('qtl2geno_reverse_index_founders', PACKAGE = 'qtl2geno', cross_info)
+}
+
 .find_ibd_segments <- function(g1, g2, p, error_prob) {
     .Call('qtl2geno_find_ibd_segments', PACKAGE = 'qtl2geno', g1, g2, p, error_prob)
 }

--- a/R/read_cross2.R
+++ b/R/read_cross2.R
@@ -172,7 +172,7 @@ function(file, quiet=TRUE)
     # pull out a map; make it numeric
     if("gmap" %in% names(output))
         map <- output$gmap
-    else if("pmap" %in% output)
+    else if("pmap" %in% names(output))
         map <- output$pmap
     else stop("Need a genetic or physical marker map")
     map[,2] <- as.numeric(map[,2])

--- a/R/read_cross2.R
+++ b/R/read_cross2.R
@@ -262,6 +262,7 @@ function(file, quiet=TRUE)
         mmar <- names(output$gmap[[i]])
         pmar <- names(output$pmap[[i]])
         if(is.null(pmar)) pmar <- mmar
+        if(is.null(mmar)) mmar <- pmar
         fmar <- colnames(output$founder_geno[[i]])
         if(is.null(fmar)) fmar <- gmar
 

--- a/R/read_cross2.R
+++ b/R/read_cross2.R
@@ -13,12 +13,15 @@
 #' @return Object of class \code{"cross2"}. For details, see the
 #' \href{http://kbroman.org/qtl2/assets/vignettes/developer_guide.html}{R/qtl2 developer guide}.
 #'
-#' @details A control file in \href{http://www.yaml.org}{YAML} or \href{http://www.json.org/}{JSON} format contains information about
-#' basic parameters as well as the names of the series of data files
-#' to be read. See the
-#' \href{http://kbroman.org/qtl2/pages/sampledata.html}{sample data files}
-#' and the
-#' \href{http://kbroman.org/qtl2/assets/vignettes/input_files.html}{vignette describing the input file format}.
+#' @details
+#' A control file in \href{http://www.yaml.org}{YAML} or
+#' \href{http://www.json.org/}{JSON} format contains information
+#' about basic parameters as well as the names of the series of
+#' data files to be read. See the
+#' \href{http://kbroman.org/qtl2/pages/sampledata.html}{sample
+#' data files} and the
+#' \href{http://kbroman.org/qtl2/assets/vignettes/input_files.html}{vignette
+#' describing the input file format}.
 #'
 #' @export
 #' @keywords IO

--- a/R/write_control_file.R
+++ b/R/write_control_file.R
@@ -189,7 +189,7 @@ function(output_file, crosstype=NULL, geno_file=NULL, founder_geno_file=NULL, gm
     if(!is.null(crossinfo_file)) {
         if(!is.null(crossinfo_covar))
             stop("Specify just one of crossinfo_file and crossinfo_covar")
-        if(is.null(crossinfo_codes))
+        if(!is.null(crossinfo_codes))
             warning("if crossinfo_file is specified, crossinfo_codes is ignored")
         result$cross_info <- list(file=crossinfo_file)
     }

--- a/R/write_control_file.R
+++ b/R/write_control_file.R
@@ -60,6 +60,8 @@
 #' comments at the top of the file (in the case of YAML), with each
 #' string as a line. For JSON, the comments are instead included
 #' within the control object.
+#' @param overwrite If TRUE, overwrite file if it exists. If FALSE
+#' (the default) and the file exists, stop with an error.
 #'
 #' @return (Invisibly) The data structure that was written.
 #'
@@ -116,11 +118,11 @@ function(output_file, crosstype=NULL, geno_file=NULL, founder_geno_file=NULL, gm
          geno_transposed=FALSE, founder_geno_transposed=FALSE,
          pheno_transposed=FALSE, covar_transposed=FALSE,
          phenocovar_transposed=FALSE,
-         description=NULL, comments=NULL)
+         description=NULL, comments=NULL, overwrite=FALSE)
 {
     output_file <- path.expand(output_file)
-    if(file.exists(output_file))
-        stop("The output file (", output_file, ") already exists. Please remove it first.")
+    if(!overwrite && file.exists(output_file))
+        stop("The output file (", output_file, ") already exists. Remove it first (or use overwrite=TRUE).")
 
     result <- list(description="", # stub to be replaced or removed
                    comments="", # stub to be replaced or removed

--- a/man/read_cross2.Rd
+++ b/man/read_cross2.Rd
@@ -23,12 +23,14 @@ Object of class \code{"cross2"}. For details, see the
 Read QTL data from a set of files
 }
 \details{
-A control file in \href{http://www.yaml.org}{YAML} or \href{http://www.json.org/}{JSON} format contains information about
-basic parameters as well as the names of the series of data files
-to be read. See the
-\href{http://kbroman.org/qtl2/pages/sampledata.html}{sample data files}
-and the
-\href{http://kbroman.org/qtl2/assets/vignettes/input_files.html}{vignette describing the input file format}.
+A control file in \href{http://www.yaml.org}{YAML} or
+\href{http://www.json.org/}{JSON} format contains information
+about basic parameters as well as the names of the series of
+data files to be read. See the
+\href{http://kbroman.org/qtl2/pages/sampledata.html}{sample
+data files} and the
+\href{http://kbroman.org/qtl2/assets/vignettes/input_files.html}{vignette
+describing the input file format}.
 }
 \examples{
 \dontrun{

--- a/man/write_control_file.Rd
+++ b/man/write_control_file.Rd
@@ -13,7 +13,7 @@ write_control_file(output_file, crosstype = NULL, geno_file = NULL,
   na.strings = c("-", "NA"), comment.char = "#", geno_transposed = FALSE,
   founder_geno_transposed = FALSE, pheno_transposed = FALSE,
   covar_transposed = FALSE, phenocovar_transposed = FALSE,
-  description = NULL, comments = NULL)
+  description = NULL, comments = NULL, overwrite = FALSE)
 }
 \arguments{
 \item{output_file}{File name (with path) of the
@@ -98,6 +98,9 @@ character in a set of leading comment lines in the data files.}
 comments at the top of the file (in the case of YAML), with each
 string as a line. For JSON, the comments are instead included
 within the control object.}
+
+\item{overwrite}{If TRUE, overwrite file if it exists. If FALSE
+(the default) and the file exists, stop with an error.}
 }
 \value{
 (Invisibly) The data structure that was written.

--- a/src/RcppExports.cpp
+++ b/src/RcppExports.cpp
@@ -156,6 +156,17 @@ BEGIN_RCPP
     return rcpp_result_gen;
 END_RCPP
 }
+// reverse_index_founders
+IntegerVector reverse_index_founders(IntegerVector cross_info);
+RcppExport SEXP qtl2geno_reverse_index_founders(SEXP cross_infoSEXP) {
+BEGIN_RCPP
+    Rcpp::RObject rcpp_result_gen;
+    Rcpp::RNGScope rcpp_rngScope_gen;
+    Rcpp::traits::input_parameter< IntegerVector >::type cross_info(cross_infoSEXP);
+    rcpp_result_gen = Rcpp::wrap(reverse_index_founders(cross_info));
+    return rcpp_result_gen;
+END_RCPP
+}
 // find_ibd_segments
 NumericMatrix find_ibd_segments(const IntegerVector& g1, const IntegerVector& g2, const NumericVector& p, const double error_prob);
 RcppExport SEXP qtl2geno_find_ibd_segments(SEXP g1SEXP, SEXP g2SEXP, SEXP pSEXP, SEXP error_probSEXP) {

--- a/src/cross.cpp
+++ b/src/cross.cpp
@@ -24,6 +24,7 @@
 #include "cross_dof1.h"
 #include "cross_hs.h"
 #include "cross_hspk.h"
+#include "cross_riself16.h"
 
 QTLCross* QTLCross::Create(const String& crosstype)
 {
@@ -41,6 +42,7 @@ QTLCross* QTLCross::Create(const String& crosstype)
     if(crosstype=="dof1")   return new DOF1();
     if(crosstype=="hs")     return new HS();
     if(crosstype=="hspk")   return new HSPK();
+    if(crosstype=="riself16") return new RISELF16();
 
     throw std::range_error("cross type not yet supported.");
     return NULL;

--- a/src/cross.cpp
+++ b/src/cross.cpp
@@ -24,6 +24,8 @@
 #include "cross_dof1.h"
 #include "cross_hs.h"
 #include "cross_hspk.h"
+#include "cross_riself4.h"
+#include "cross_riself8.h"
 #include "cross_riself16.h"
 
 QTLCross* QTLCross::Create(const String& crosstype)
@@ -42,6 +44,8 @@ QTLCross* QTLCross::Create(const String& crosstype)
     if(crosstype=="dof1")   return new DOF1();
     if(crosstype=="hs")     return new HS();
     if(crosstype=="hspk")   return new HSPK();
+    if(crosstype=="riself4") return new RISELF4();
+    if(crosstype=="riself8") return new RISELF8();
     if(crosstype=="riself16") return new RISELF16();
 
     throw std::range_error("cross type not yet supported.");

--- a/src/cross.h
+++ b/src/cross.h
@@ -156,20 +156,12 @@ public:
     // check that cross_info conforms to expectation
     virtual const bool check_crossinfo(const Rcpp::IntegerMatrix& cross_info, const bool any_x_chr)
     {
-        //const int n_col = cross_info.cols();
-        //if(n_col > 0)
-        //    REprintf("cross_info provided (with %d columns) but ignored for this cross type\n", n_col);
-
         return true; // don't call it an error
     }
 
     // check that sex conforms to expectation
     virtual const bool check_is_female_vector(const Rcpp::LogicalVector& is_female, const bool any_x_chr)
     {
-        //const int n = is_female.size();
-        //if(n > 0)
-        //    REprintf("is_female provided but ignored for this cross type\n");
-
         return true; // don't call it an error
     }
 

--- a/src/cross_ail.cpp
+++ b/src/cross_ail.cpp
@@ -499,7 +499,13 @@ const int AIL::nrec(const int gen_left, const int gen_right,
                     const bool is_x_chr, const bool is_female,
                     const Rcpp::IntegerVector& cross_info)
 {
-    if(!is_x_chr) {
+    #ifndef NDEBUG
+    if(!check_geno(gen_left, false, is_x_chr, is_female, cross_info) ||
+       !check_geno(gen_right, false, is_x_chr, is_female, cross_info))
+        throw std::range_error("genotype value not allowed");
+    #endif
+
+    if(!is_x_chr || is_female) {
         switch(gen_left) {
         case 1:
             switch(gen_right) {
@@ -520,7 +526,7 @@ const int AIL::nrec(const int gen_left, const int gen_right,
             }
         }
     }
-    else { // X chromosome
+    else { // X chromosome, males (possible values are 4 or 5)
         if(gen_left == gen_right) return(0);
         else return(1);
     }

--- a/src/cross_bc.cpp
+++ b/src/cross_bc.cpp
@@ -102,19 +102,6 @@ const int BC::ngen(const bool is_x_chr)
 }
 
 
-const int BC::nrec(const int gen_left, const int gen_right,
-                   const bool is_x_chr, const bool is_female, const IntegerVector& cross_info)
-{
-    #ifndef NDEBUG
-    if(!check_geno(gen_left, false, is_x_chr, is_female, cross_info) ||
-       !check_geno(gen_right, false, is_x_chr, is_female, cross_info))
-        throw std::range_error("genotype value not allowed");
-    #endif
-
-    if(gen_left == gen_right) return 0;
-    else return 1;
-}
-
 // check that sex conforms to expectation
 const bool BC::check_is_female_vector(const LogicalVector& is_female, const bool any_x_chr)
 {

--- a/src/cross_bc.h
+++ b/src/cross_bc.h
@@ -30,10 +30,6 @@ class BC : public QTLCross
                                            const Rcpp::IntegerVector& cross_info);
     const int ngen(const bool is_x_chr);
 
-    const int nrec(const int gen_left, const int gen_right,
-                   const bool is_x_chr, const bool is_female,
-                   const Rcpp::IntegerVector& cross_info);
-
     const bool check_is_female_vector(const Rcpp::LogicalVector& is_female, const bool any_x_chr);
 
     const std::vector<std::string> geno_names(const std::vector<std::string> alleles,

--- a/src/cross_do.cpp
+++ b/src/cross_do.cpp
@@ -368,6 +368,12 @@ const int DO::nrec(const int gen_left, const int gen_right,
                    const bool is_x_chr, const bool is_female,
                    const Rcpp::IntegerVector& cross_info)
 {
+    #ifndef NDEBUG
+    if(!check_geno(gen_left, false, is_x_chr, is_female, cross_info) ||
+       !check_geno(gen_right, false, is_x_chr, is_female, cross_info))
+        throw std::range_error("genotype value not allowed");
+    #endif
+
     if(is_x_chr && gen_left > 36 && gen_right > 36) { // male X chromosome
         if(gen_left == gen_right) return(0);
         else return(1);

--- a/src/cross_dof1.cpp
+++ b/src/cross_dof1.cpp
@@ -351,3 +351,11 @@ const std::vector<std::string> DOF1::geno_names(const std::vector<std::string> a
         return result;
     }
 }
+
+const double DOF1::est_rec_frac(const NumericVector& gamma, const bool is_x_chr,
+                                const IntegerMatrix& cross_info, const int n_gen)
+{
+    Rcpp::stop("est_map not yet available for Diversity Outcross F1");
+
+    return NA_REAL;
+}

--- a/src/cross_dof1.h
+++ b/src/cross_dof1.h
@@ -42,6 +42,9 @@ class DOF1 : public QTLCross
     const bool need_founder_geno();
 
     const std::vector<std::string> geno_names(const std::vector<std::string> alleles, const bool is_x_chr);
+
+    const double est_rec_frac(const Rcpp::NumericVector& gamma, const bool is_x_chr,
+                              const Rcpp::IntegerMatrix& cross_info, const int n_gen);
 };
 
 #endif // CROSS_DOF1_H

--- a/src/cross_dopk.cpp
+++ b/src/cross_dopk.cpp
@@ -218,8 +218,35 @@ const int DOPK::nrec(const int gen_left, const int gen_right,
                      const bool is_x_chr, const bool is_female,
                      const IntegerVector& cross_info)
 {
-    // need to fill in this function
-    return NA_INTEGER;
+    #ifndef NDEBUG
+    if(!check_geno(gen_left, true, is_x_chr, is_female, cross_info) ||
+       !check_geno(gen_right, true, is_x_chr, is_female, cross_info))
+        throw std::range_error("genotype value not allowed");
+    #endif
+
+    if(is_x_chr && gen_left > 64 && gen_right > 64) { // male X chromosome
+        if(gen_left == gen_right) return(0);
+        else return(1);
+    }
+
+    Rcpp::IntegerVector a_left = mpp_decode_geno(gen_left, 8, true);
+    Rcpp::IntegerVector a_right = mpp_decode_geno(gen_right, 8, true);
+
+    if(a_left[0] == a_right[0]) {
+        if(a_left[1] == a_right[1]) return(0);
+        else return(1);
+    }
+    else if(a_left[0] == a_right[1]) {
+        if(a_left[1] == a_right[0]) return(0);
+        else return(1);
+    }
+    else if(a_left[1] == a_right[0]) {
+        return(1);
+    }
+    else if(a_left[1] == a_right[1]) {
+        return(1);
+    }
+    else return(2);
 }
 
 const double DOPK::est_rec_frac(const NumericVector& gamma, const bool is_x_chr,

--- a/src/cross_f2.cpp
+++ b/src/cross_f2.cpp
@@ -382,6 +382,12 @@ const int F2::nrec(const int gen_left, const int gen_right,
                    const bool is_x_chr, const bool is_female,
                    const Rcpp::IntegerVector& cross_info)
 {
+    #ifndef NDEBUG
+    if(!check_geno(gen_left, false, is_x_chr, is_female, cross_info) ||
+       !check_geno(gen_right, false, is_x_chr, is_female, cross_info))
+        throw std::range_error("genotype value not allowed");
+    #endif
+
     if(!is_x_chr) {
         switch(gen_left) {
         case 1:

--- a/src/cross_hs.cpp
+++ b/src/cross_hs.cpp
@@ -389,6 +389,12 @@ const int HS::nrec(const int gen_left, const int gen_right,
                    const bool is_x_chr, const bool is_female,
                    const Rcpp::IntegerVector& cross_info)
 {
+    #ifndef NDEBUG
+    if(!check_geno(gen_left, false, is_x_chr, is_female, cross_info) ||
+       !check_geno(gen_right, false, is_x_chr, is_female, cross_info))
+        throw std::range_error("genotype value not allowed");
+    #endif
+
     if(is_x_chr && gen_left > 36 && gen_right > 36) { // male X chromosome
         if(gen_left == gen_right) return(0);
         else return(1);

--- a/src/cross_hspk.cpp
+++ b/src/cross_hspk.cpp
@@ -218,8 +218,35 @@ const int HSPK::nrec(const int gen_left, const int gen_right,
                      const bool is_x_chr, const bool is_female,
                      const IntegerVector& cross_info)
 {
-    // need to fill in this function
-    return NA_INTEGER;
+    #ifndef NDEBUG
+    if(!check_geno(gen_left, true, is_x_chr, is_female, cross_info) ||
+       !check_geno(gen_right, true, is_x_chr, is_female, cross_info))
+        throw std::range_error("genotype value not allowed");
+    #endif
+
+    if(is_x_chr && gen_left > 64 && gen_right > 64) { // male X chromosome
+        if(gen_left == gen_right) return(0);
+        else return(1);
+    }
+
+    Rcpp::IntegerVector a_left = mpp_decode_geno(gen_left, 8, true);
+    Rcpp::IntegerVector a_right = mpp_decode_geno(gen_right, 8, true);
+
+    if(a_left[0] == a_right[0]) {
+        if(a_left[1] == a_right[1]) return(0);
+        else return(1);
+    }
+    else if(a_left[0] == a_right[1]) {
+        if(a_left[1] == a_right[0]) return(0);
+        else return(1);
+    }
+    else if(a_left[1] == a_right[0]) {
+        return(1);
+    }
+    else if(a_left[1] == a_right[1]) {
+        return(1);
+    }
+    else return(2);
 }
 
 const double HSPK::est_rec_frac(const NumericVector& gamma, const bool is_x_chr,

--- a/src/cross_riself16.cpp
+++ b/src/cross_riself16.cpp
@@ -1,0 +1,236 @@
+// 16-way RIL by selfing QTLCross class (for HMM)
+
+#include "cross_riself16.h"
+#include <math.h>
+#include <Rcpp.h>
+#include "cross.h"
+#include "cross_util.h"
+#include "cross_do_util.h"
+#include "r_message.h"
+
+enum gen {A=1, H=2, B=3, notA=5, notB=4};
+
+const bool RISELF16::check_geno(const int gen, const bool is_observed_value,
+                                const bool is_x_chr, const bool is_female,
+                                const IntegerVector& cross_info)
+{
+    // allow any value 0-5 for observed
+    if(is_observed_value) {
+        if(gen==0 || gen==A || gen==H || gen==B ||
+           gen==notA || gen==notB) return true;
+        else return false;
+    }
+
+    const int n_geno = 16;
+
+    if(gen>= 1 && gen <= n_geno) return true;
+
+    return false; // otherwise a problem
+}
+
+const double RISELF16::init(const int true_gen,
+                            const bool is_x_chr, const bool is_female,
+                            const IntegerVector& cross_info)
+{
+    #ifndef NDEBUG
+    if(!check_geno(true_gen, false, is_x_chr, is_female, cross_info))
+        throw std::range_error("genotype value not allowed");
+    #endif
+
+    return -log(16.0);
+}
+
+const double RISELF16::emit(const int obs_gen, const int true_gen, const double error_prob,
+                            const IntegerVector& founder_geno, const bool is_x_chr,
+                            const bool is_female, const IntegerVector& cross_info)
+{
+    #ifndef NDEBUG
+    if(!check_geno(true_gen, false, is_x_chr, is_female, cross_info))
+        throw std::range_error("genotype value not allowed");
+    #endif
+
+    if(obs_gen==0) return 0.0; // missing
+
+    int f = founder_geno[true_gen-1]; // founder allele
+    if(f!=1 && f!=3) return 0.0;      // founder missing -> no information
+
+    if(f == obs_gen) return log(1.0 - error_prob);
+
+    return log(error_prob); // genotyping error
+}
+
+
+const double RISELF16::step(const int gen_left, const int gen_right, const double rec_frac,
+                            const bool is_x_chr, const bool is_female,
+                            const IntegerVector& cross_info)
+{
+    #ifndef NDEBUG
+    if(!check_geno(gen_left, false, is_x_chr, is_female, cross_info) ||
+       !check_geno(gen_right, false, is_x_chr, is_female, cross_info))
+        throw std::range_error("genotype value not allowed");
+    #endif
+
+    // FIX_ME
+    // oy this is a bit tricky; need to use cross_info
+
+    return(NA_REAL);
+}
+
+const IntegerVector RISELF16::possible_gen(const bool is_x_chr, const bool is_female,
+                                       const IntegerVector& cross_info)
+{
+    int n_geno = 8;
+    IntegerVector result(n_geno);
+
+    for(int i=0; i<n_geno; i++) result[i] = i+1;
+    return result;
+}
+
+const int RISELF16::ngen(const bool is_x_chr)
+{
+    return 8;
+}
+
+const int RISELF16::nalleles()
+{
+    return 8;
+}
+
+
+// check that cross_info conforms to expectation
+const bool RISELF16::check_crossinfo(const IntegerMatrix& cross_info, const bool any_x_chr)
+{
+    bool result = true;
+    const int n_row = cross_info.rows();
+    const int n_col = cross_info.cols();
+    // 16 columns with order of cross
+
+    if(n_col != 16) {
+        result = false;
+        r_message("cross_info not provided, but should 16 columns, indicating the order of the cross");
+        return result;
+    }
+
+    int n_missing=0;
+    int n_invalid=0;
+    for(int i=0; i<n_row; i++) {
+        for(int j=0; j<n_col; j++) {
+            if(cross_info(i,j) == NA_INTEGER) ++n_missing;
+            else if(cross_info(i,j) < 1 || cross_info(i,j)>n_col) ++n_invalid;
+        }
+        // count values 1..ncol
+        IntegerVector counts(n_col);
+        for(int j=0; j<n_col; j++) counts[j] = 0; // zero counts
+        for(int j=0; j<n_col; j++) ++counts[cross_info(i,j)-1]; // count values
+        for(int j=0; j<n_col; j++) {
+            if(counts[j] != 1) n_invalid += abs(counts[j] - 1);
+        }
+    }
+    if(n_missing > 0) {
+        result = false;
+        r_message("cross_info has missing values (it shouldn't)");
+    }
+    if(n_invalid > 0) {
+        result = false;
+        r_message("cross_info has invalid values; each row should be permutation of {1, 2, ..., 16}");
+    }
+
+    return result;
+}
+
+
+// check that founder genotype data has correct no. founders and markers
+const bool RISELF16::check_founder_geno_size(const IntegerMatrix& founder_geno, const int n_markers)
+{
+    bool result=true;
+
+    const int fg_mar = founder_geno.cols();
+    const int fg_f   = founder_geno.rows();
+
+    if(fg_mar != n_markers) {
+        result = false;
+        r_message("founder_geno has incorrect number of markers");
+    }
+
+    if(fg_f != 16) {
+        result = false;
+        r_message("founder_geno should have 16 founders");
+    }
+
+    return result;
+}
+
+// check that founder genotype data has correct values
+const bool RISELF16::check_founder_geno_values(const IntegerMatrix& founder_geno)
+{
+    const int fg_mar = founder_geno.cols();
+    const int fg_f   = founder_geno.rows();
+
+    for(int f=0; f<fg_f; f++) {
+        for(int mar=0; mar<fg_mar; mar++) {
+            int fg = founder_geno(f,mar);
+            if(fg != 0 && fg != 1 && fg != 3) {
+                // at least one invalid value
+                r_message("founder_geno contains invalid values; should be in {0, 1, 3}");
+                return false;
+            }
+        }
+    }
+
+    return true;
+}
+
+const bool RISELF16::need_founder_geno()
+{
+    return true;
+}
+
+// geno_names from allele names
+const std::vector<std::string> RISELF16::geno_names(const std::vector<std::string> alleles,
+                                                const bool is_x_chr)
+{
+    int n_alleles = alleles.size();
+
+    if(alleles.size() < 16)
+        throw std::range_error("alleles must have length 16");
+
+    std::vector<std::string> result(n_alleles);
+
+    for(int i=0; i<n_alleles; i++)
+        result[i] = alleles[i];
+
+    return result;
+}
+
+
+const int RISELF16::nrec(const int gen_left, const int gen_right,
+                         const bool is_x_chr, const bool is_female,
+                         const Rcpp::IntegerVector& cross_info)
+{
+    #ifndef NDEBUG
+    if(!check_geno(gen_left, false, is_x_chr, is_female, cross_info) ||
+       !check_geno(gen_right, false, is_x_chr, is_female, cross_info))
+        throw std::range_error("genotype value not allowed");
+    #endif
+
+    if(gen_left == gen_right) return 0;
+    else return 1;
+}
+
+const double RISELF16::est_rec_frac(const Rcpp::NumericVector& gamma, const bool is_x_chr,
+                                    const Rcpp::IntegerMatrix& cross_info, const int n_gen)
+{
+    // FIX_ME need to implement this
+    return(NA_REAL);
+}
+
+// check whether X chr can be handled
+const bool RISELF16::check_handle_x_chr(const bool any_x_chr)
+{
+    if(any_x_chr) {
+        r_message("X chr ignored for RIL by selfing.");
+        return false;
+    }
+
+    return true; // most crosses can handle the X chr
+}

--- a/src/cross_riself16.cpp
+++ b/src/cross_riself16.cpp
@@ -70,16 +70,29 @@ const double RISELF16::step(const int gen_left, const int gen_right, const doubl
         throw std::range_error("genotype value not allowed");
     #endif
 
-    // FIX_ME
-    // oy this is a bit tricky; need to use cross_info
+    if(gen_left == gen_right)
+        return 3.0*log(1.0-rec_frac) - log(16.0) - log(1.0 + 2.0 * rec_frac);
 
-    return(NA_REAL);
+    // first get reverse index of cross info
+    IntegerVector founder_index = reverse_index_founders(cross_info);
+
+    // were the two founders crossed to each other at the first generation?
+    if(founder_index[gen_left-1] / 2 == founder_index[gen_right-1] / 2) // next to each other
+        return log(rec_frac) + 2.0*log(1.0 - rec_frac) - log(16.0) - log(1.0 + 2.0 * rec_frac);
+
+    // were the two founders in the same group of 4?
+    if(founder_index[gen_left-1] / 4 == founder_index[gen_right-1] / 4)
+        return log(rec_frac) + log(1.0 - rec_frac) - log(32.0) - log(1.0 + 2.0 * rec_frac);
+
+    // off the block-diagonal
+    return log(rec_frac) - log(64.0) - log(1.0 + 2.0 * rec_frac);
+
 }
 
 const IntegerVector RISELF16::possible_gen(const bool is_x_chr, const bool is_female,
                                        const IntegerVector& cross_info)
 {
-    int n_geno = 8;
+    int n_geno = 16;
     IntegerVector result(n_geno);
 
     for(int i=0; i<n_geno; i++) result[i] = i+1;
@@ -88,12 +101,12 @@ const IntegerVector RISELF16::possible_gen(const bool is_x_chr, const bool is_fe
 
 const int RISELF16::ngen(const bool is_x_chr)
 {
-    return 8;
+    return 16;
 }
 
 const int RISELF16::nalleles()
 {
-    return 8;
+    return 16;
 }
 
 

--- a/src/cross_riself16.h
+++ b/src/cross_riself16.h
@@ -1,0 +1,54 @@
+// 16-way RIL by selfing QTLCross class (for HMM)
+
+#ifndef CROSS_RISELF16_H
+#define CROSS_RISELF16_H
+
+#include <Rcpp.h>
+#include "cross.h"
+
+class RISELF16 : public QTLCross
+{
+ public:
+    RISELF16(){
+        crosstype = "riself16";
+        phase_known_crosstype = "riself16";
+    };
+    ~RISELF16(){};
+
+    const bool check_geno(const int gen, const bool is_observed_value,
+                          const bool is_x_chr, const bool is_female, const Rcpp::IntegerVector& cross_info);
+
+    const double init(const int true_gen,
+                      const bool is_x_chr, const bool is_female, const Rcpp::IntegerVector& cross_info);
+    const double emit(const int obs_gen, const int true_gen, const double error_prob,
+                      const Rcpp::IntegerVector& founder_geno, const bool is_x_chr,
+                      const bool is_female, const Rcpp::IntegerVector& cross_info);
+    const double step(const int gen_left, const int gen_right, const double rec_frac,
+                      const bool is_x_chr, const bool is_female, const Rcpp::IntegerVector& cross_info);
+
+    const Rcpp::IntegerVector possible_gen(const bool is_x_chr, const bool is_female, const Rcpp::IntegerVector& cross_info);
+
+    const int ngen(const bool is_x_chr);
+    const int nalleles();
+
+    const bool check_crossinfo(const Rcpp::IntegerMatrix& cross_info, const bool any_x_chr);
+
+    const bool check_founder_geno_size(const Rcpp::IntegerMatrix& founder_geno, const int n_markers);
+    const bool check_founder_geno_values(const Rcpp::IntegerMatrix& founder_geno);
+    const bool need_founder_geno();
+
+    const std::vector<std::string> geno_names(const std::vector<std::string> alleles, const bool is_x_chr);
+
+    const int nrec(const int gen_left, const int gen_right,
+                   const bool is_x_chr, const bool is_female,
+                   const Rcpp::IntegerVector& cross_info);
+
+    const double est_rec_frac(const Rcpp::NumericVector& gamma, const bool is_x_chr,
+                              const Rcpp::IntegerMatrix& cross_info, const int n_gen);
+
+    // check whether X chr can be handled
+    const bool check_handle_x_chr(const bool any_x_chr);
+
+};
+
+#endif // CROSS_RISELF16_H

--- a/src/cross_riself4.cpp
+++ b/src/cross_riself4.cpp
@@ -1,0 +1,236 @@
+// 4-way RIL by selfing QTLCross class (for HMM)
+
+#include "cross_riself4.h"
+#include <math.h>
+#include <Rcpp.h>
+#include "cross.h"
+#include "cross_util.h"
+#include "cross_do_util.h"
+#include "r_message.h"
+
+enum gen {A=1, H=2, B=3, notA=5, notB=4};
+
+const bool RISELF4::check_geno(const int gen, const bool is_observed_value,
+                                const bool is_x_chr, const bool is_female,
+                                const IntegerVector& cross_info)
+{
+    // allow any value 0-5 for observed
+    if(is_observed_value) {
+        if(gen==0 || gen==A || gen==H || gen==B ||
+           gen==notA || gen==notB) return true;
+        else return false;
+    }
+
+    const int n_geno = 4;
+
+    if(gen>= 1 && gen <= n_geno) return true;
+
+    return false; // otherwise a problem
+}
+
+const double RISELF4::init(const int true_gen,
+                            const bool is_x_chr, const bool is_female,
+                            const IntegerVector& cross_info)
+{
+    #ifndef NDEBUG
+    if(!check_geno(true_gen, false, is_x_chr, is_female, cross_info))
+        throw std::range_error("genotype value not allowed");
+    #endif
+
+    return -log(4.0);
+}
+
+const double RISELF4::emit(const int obs_gen, const int true_gen, const double error_prob,
+                            const IntegerVector& founder_geno, const bool is_x_chr,
+                            const bool is_female, const IntegerVector& cross_info)
+{
+    #ifndef NDEBUG
+    if(!check_geno(true_gen, false, is_x_chr, is_female, cross_info))
+        throw std::range_error("genotype value not allowed");
+    #endif
+
+    if(obs_gen==0) return 0.0; // missing
+
+    int f = founder_geno[true_gen-1]; // founder allele
+    if(f!=1 && f!=3) return 0.0;      // founder missing -> no information
+
+    if(f == obs_gen) return log(1.0 - error_prob);
+
+    return log(error_prob); // genotyping error
+}
+
+
+const double RISELF4::step(const int gen_left, const int gen_right, const double rec_frac,
+                            const bool is_x_chr, const bool is_female,
+                            const IntegerVector& cross_info)
+{
+    #ifndef NDEBUG
+    if(!check_geno(gen_left, false, is_x_chr, is_female, cross_info) ||
+       !check_geno(gen_right, false, is_x_chr, is_female, cross_info))
+        throw std::range_error("genotype value not allowed");
+    #endif
+
+    // FIX_ME
+    // oy this is a bit tricky; need to use cross_info
+
+    return(NA_REAL);
+}
+
+const IntegerVector RISELF4::possible_gen(const bool is_x_chr, const bool is_female,
+                                       const IntegerVector& cross_info)
+{
+    int n_geno = 4;
+    IntegerVector result(n_geno);
+
+    for(int i=0; i<n_geno; i++) result[i] = i+1;
+    return result;
+}
+
+const int RISELF4::ngen(const bool is_x_chr)
+{
+    return 4;
+}
+
+const int RISELF4::nalleles()
+{
+    return 4;
+}
+
+
+// check that cross_info conforms to expectation
+const bool RISELF4::check_crossinfo(const IntegerMatrix& cross_info, const bool any_x_chr)
+{
+    bool result = true;
+    const int n_row = cross_info.rows();
+    const int n_col = cross_info.cols();
+    // 4 columns with order of cross
+
+    if(n_col != 4) {
+        result = false;
+        r_message("cross_info not provided, but should 4 columns, indicating the order of the cross");
+        return result;
+    }
+
+    int n_missing=0;
+    int n_invalid=0;
+    for(int i=0; i<n_row; i++) {
+        for(int j=0; j<n_col; j++) {
+            if(cross_info(i,j) == NA_INTEGER) ++n_missing;
+            else if(cross_info(i,j) < 1 || cross_info(i,j)>n_col) ++n_invalid;
+        }
+        // count values 1..ncol
+        IntegerVector counts(n_col);
+        for(int j=0; j<n_col; j++) counts[j] = 0; // zero counts
+        for(int j=0; j<n_col; j++) ++counts[cross_info(i,j)-1]; // count values
+        for(int j=0; j<n_col; j++) {
+            if(counts[j] != 1) n_invalid += abs(counts[j] - 1);
+        }
+    }
+    if(n_missing > 0) {
+        result = false;
+        r_message("cross_info has missing values (it shouldn't)");
+    }
+    if(n_invalid > 0) {
+        result = false;
+        r_message("cross_info has invalid values; each row should be permutation of {1, 2, ..., 4}");
+    }
+
+    return result;
+}
+
+
+// check that founder genotype data has correct no. founders and markers
+const bool RISELF4::check_founder_geno_size(const IntegerMatrix& founder_geno, const int n_markers)
+{
+    bool result=true;
+
+    const int fg_mar = founder_geno.cols();
+    const int fg_f   = founder_geno.rows();
+
+    if(fg_mar != n_markers) {
+        result = false;
+        r_message("founder_geno has incorrect number of markers");
+    }
+
+    if(fg_f != 4) {
+        result = false;
+        r_message("founder_geno should have 4 founders");
+    }
+
+    return result;
+}
+
+// check that founder genotype data has correct values
+const bool RISELF4::check_founder_geno_values(const IntegerMatrix& founder_geno)
+{
+    const int fg_mar = founder_geno.cols();
+    const int fg_f   = founder_geno.rows();
+
+    for(int f=0; f<fg_f; f++) {
+        for(int mar=0; mar<fg_mar; mar++) {
+            int fg = founder_geno(f,mar);
+            if(fg != 0 && fg != 1 && fg != 3) {
+                // at least one invalid value
+                r_message("founder_geno contains invalid values; should be in {0, 1, 3}");
+                return false;
+            }
+        }
+    }
+
+    return true;
+}
+
+const bool RISELF4::need_founder_geno()
+{
+    return true;
+}
+
+// geno_names from allele names
+const std::vector<std::string> RISELF4::geno_names(const std::vector<std::string> alleles,
+                                                const bool is_x_chr)
+{
+    int n_alleles = alleles.size();
+
+    if(alleles.size() < 4)
+        throw std::range_error("alleles must have length 4");
+
+    std::vector<std::string> result(n_alleles);
+
+    for(int i=0; i<n_alleles; i++)
+        result[i] = alleles[i];
+
+    return result;
+}
+
+
+const int RISELF4::nrec(const int gen_left, const int gen_right,
+                         const bool is_x_chr, const bool is_female,
+                         const Rcpp::IntegerVector& cross_info)
+{
+    #ifndef NDEBUG
+    if(!check_geno(gen_left, false, is_x_chr, is_female, cross_info) ||
+       !check_geno(gen_right, false, is_x_chr, is_female, cross_info))
+        throw std::range_error("genotype value not allowed");
+    #endif
+
+    if(gen_left == gen_right) return 0;
+    else return 1;
+}
+
+const double RISELF4::est_rec_frac(const Rcpp::NumericVector& gamma, const bool is_x_chr,
+                                    const Rcpp::IntegerMatrix& cross_info, const int n_gen)
+{
+    // FIX_ME need to implement this
+    return(NA_REAL);
+}
+
+// check whether X chr can be handled
+const bool RISELF4::check_handle_x_chr(const bool any_x_chr)
+{
+    if(any_x_chr) {
+        r_message("X chr ignored for RIL by selfing.");
+        return false;
+    }
+
+    return true; // most crosses can handle the X chr
+}

--- a/src/cross_riself4.cpp
+++ b/src/cross_riself4.cpp
@@ -70,10 +70,10 @@ const double RISELF4::step(const int gen_left, const int gen_right, const double
         throw std::range_error("genotype value not allowed");
     #endif
 
-    // FIX_ME
-    // oy this is a bit tricky; need to use cross_info
-
-    return(NA_REAL);
+    if(gen_left != gen_right)
+        return log(rec_frac) - log(4.0) - log(1.0 + 2.0*rec_frac);
+    else
+        return log(1.0 - rec_frac) - log(4.0) - log(1.0 + 2.0*rec_frac);
 }
 
 const IntegerVector RISELF4::possible_gen(const bool is_x_chr, const bool is_female,
@@ -220,8 +220,10 @@ const int RISELF4::nrec(const int gen_left, const int gen_right,
 const double RISELF4::est_rec_frac(const Rcpp::NumericVector& gamma, const bool is_x_chr,
                                     const Rcpp::IntegerMatrix& cross_info, const int n_gen)
 {
-    // FIX_ME need to implement this
-    return(NA_REAL);
+    double R = QTLCross::est_rec_frac(gamma, is_x_chr, cross_info, n_gen);
+
+    // inverse of R = 3r/(1+2r)
+    return R/(3.0 - 2.0*R);
 }
 
 // check whether X chr can be handled

--- a/src/cross_riself4.h
+++ b/src/cross_riself4.h
@@ -1,0 +1,54 @@
+// 4-way RIL by selfing QTLCross class (for HMM)
+
+#ifndef CROSS_RISELF4_H
+#define CROSS_RISELF4_H
+
+#include <Rcpp.h>
+#include "cross.h"
+
+class RISELF4 : public QTLCross
+{
+ public:
+    RISELF4(){
+        crosstype = "riself4";
+        phase_known_crosstype = "riself4";
+    };
+    ~RISELF4(){};
+
+    const bool check_geno(const int gen, const bool is_observed_value,
+                          const bool is_x_chr, const bool is_female, const Rcpp::IntegerVector& cross_info);
+
+    const double init(const int true_gen,
+                      const bool is_x_chr, const bool is_female, const Rcpp::IntegerVector& cross_info);
+    const double emit(const int obs_gen, const int true_gen, const double error_prob,
+                      const Rcpp::IntegerVector& founder_geno, const bool is_x_chr,
+                      const bool is_female, const Rcpp::IntegerVector& cross_info);
+    const double step(const int gen_left, const int gen_right, const double rec_frac,
+                      const bool is_x_chr, const bool is_female, const Rcpp::IntegerVector& cross_info);
+
+    const Rcpp::IntegerVector possible_gen(const bool is_x_chr, const bool is_female, const Rcpp::IntegerVector& cross_info);
+
+    const int ngen(const bool is_x_chr);
+    const int nalleles();
+
+    const bool check_crossinfo(const Rcpp::IntegerMatrix& cross_info, const bool any_x_chr);
+
+    const bool check_founder_geno_size(const Rcpp::IntegerMatrix& founder_geno, const int n_markers);
+    const bool check_founder_geno_values(const Rcpp::IntegerMatrix& founder_geno);
+    const bool need_founder_geno();
+
+    const std::vector<std::string> geno_names(const std::vector<std::string> alleles, const bool is_x_chr);
+
+    const int nrec(const int gen_left, const int gen_right,
+                   const bool is_x_chr, const bool is_female,
+                   const Rcpp::IntegerVector& cross_info);
+
+    const double est_rec_frac(const Rcpp::NumericVector& gamma, const bool is_x_chr,
+                              const Rcpp::IntegerMatrix& cross_info, const int n_gen);
+
+    // check whether X chr can be handled
+    const bool check_handle_x_chr(const bool any_x_chr);
+
+};
+
+#endif // CROSS_RISELF4_H

--- a/src/cross_riself8.cpp
+++ b/src/cross_riself8.cpp
@@ -70,10 +70,18 @@ const double RISELF8::step(const int gen_left, const int gen_right, const double
         throw std::range_error("genotype value not allowed");
     #endif
 
-    // FIX_ME
-    // oy this is a bit tricky; need to use cross_info
+    if(gen_left == gen_right)
+        return 2.0*log(1.0-rec_frac) - log(8.0) - log(1.0 + 2.0 * rec_frac);
 
-    return(NA_REAL);
+    // first get reverse index of cross info
+    IntegerVector founder_index = reverse_index_founders(cross_info);
+
+    // were the two founders crossed to each other directly?
+    if(founder_index[gen_left-1] / 2 == founder_index[gen_right-1] / 2) // next to each other
+        return log(rec_frac) + log(1.0 - rec_frac) - log(8.0) - log(1.0 + 2.0 * rec_frac);
+
+    // off the block-diagonal
+    return log(rec_frac) - log(16.0) - log(1.0 + 2.0 * rec_frac);
 }
 
 const IntegerVector RISELF8::possible_gen(const bool is_x_chr, const bool is_female,

--- a/src/cross_riself8.cpp
+++ b/src/cross_riself8.cpp
@@ -70,6 +70,13 @@ const double RISELF8::step(const int gen_left, const int gen_right, const double
         throw std::range_error("genotype value not allowed");
     #endif
 
+    // equations are from Teuscher and Broman Genetics 175:1267-1274, 2007
+    //     doi:10.1534/genetics.106.064063
+    //     see equation 1 in right column on page 1269
+    //
+    // They also appear in Broman Genetics 169:1133-1146, 2005
+    //     doi:10.1534/genetics.104.035212
+    //     see table 2 on page 1136
     if(gen_left == gen_right)
         return 2.0*log(1.0-rec_frac) - log(8.0) - log(1.0 + 2.0 * rec_frac);
 
@@ -228,8 +235,38 @@ const int RISELF8::nrec(const int gen_left, const int gen_right,
 const double RISELF8::est_rec_frac(const Rcpp::NumericVector& gamma, const bool is_x_chr,
                                     const Rcpp::IntegerMatrix& cross_info, const int n_gen)
 {
-    // FIX_ME need to implement this
-    return(NA_REAL);
+    int n_ind = cross_info.cols();
+    int n_gen_sq = n_gen*n_gen;
+
+    #ifndef NDEBUG
+    if(cross_info.rows() != 8) // incorrect number of founders
+        throw std::range_error("cross_info should contain 8 founders");
+    #endif
+
+    double u=0.0, v=0.0, w=0.0; // counts of the three different patterns of 2-locus genotypes
+    for(int ind=0, offset=0; ind<n_ind; ind++, offset += n_gen_sq) {
+        IntegerVector founder_index = reverse_index_founders(cross_info(_,ind));
+
+        for(int gl=0; gl<n_gen; gl++) {
+            u += gamma[offset+gl*n_gen+gl];
+            for(int gr=gl+1; gr<n_gen; gr++) {
+                if(founder_index[gl] / 2 == founder_index[gr] / 2)
+                    v += (gamma[offset+gl*n_gen+gr] + gamma[offset+gr*n_gen+gl]);
+                else
+                    w += (gamma[offset+gl*n_gen+gr] + gamma[offset+gr*n_gen+gl]);
+            }
+        }
+    }
+    double n = u + v + w; // total
+
+    // calculate MLE of recombination fraction
+    double A = sqrt(4.0*n*n + 4.0*n*(2.0*u - 2.0*v - 3.0*w) + 9.0*w*w + 12.0*w*(u+2.0*v) +
+                    16.0*v*v + 16.0*u*v + 4.0*u*u);
+    double result = (2.0*n + 2.0*u - w - A)/4.0/(n - w - 2.0*v - 2.0*u);
+
+    if(result < 0.0) result = 0.0;
+
+    return result;
 }
 
 // check whether X chr can be handled

--- a/src/cross_riself8.cpp
+++ b/src/cross_riself8.cpp
@@ -1,0 +1,236 @@
+// 8-way RIL by selfing QTLCross class (for HMM)
+
+#include "cross_riself8.h"
+#include <math.h>
+#include <Rcpp.h>
+#include "cross.h"
+#include "cross_util.h"
+#include "cross_do_util.h"
+#include "r_message.h"
+
+enum gen {A=1, H=2, B=3, notA=5, notB=4};
+
+const bool RISELF8::check_geno(const int gen, const bool is_observed_value,
+                                const bool is_x_chr, const bool is_female,
+                                const IntegerVector& cross_info)
+{
+    // allow any value 0-5 for observed
+    if(is_observed_value) {
+        if(gen==0 || gen==A || gen==H || gen==B ||
+           gen==notA || gen==notB) return true;
+        else return false;
+    }
+
+    const int n_geno = 8;
+
+    if(gen>= 1 && gen <= n_geno) return true;
+
+    return false; // otherwise a problem
+}
+
+const double RISELF8::init(const int true_gen,
+                            const bool is_x_chr, const bool is_female,
+                            const IntegerVector& cross_info)
+{
+    #ifndef NDEBUG
+    if(!check_geno(true_gen, false, is_x_chr, is_female, cross_info))
+        throw std::range_error("genotype value not allowed");
+    #endif
+
+    return -log(8.0);
+}
+
+const double RISELF8::emit(const int obs_gen, const int true_gen, const double error_prob,
+                            const IntegerVector& founder_geno, const bool is_x_chr,
+                            const bool is_female, const IntegerVector& cross_info)
+{
+    #ifndef NDEBUG
+    if(!check_geno(true_gen, false, is_x_chr, is_female, cross_info))
+        throw std::range_error("genotype value not allowed");
+    #endif
+
+    if(obs_gen==0) return 0.0; // missing
+
+    int f = founder_geno[true_gen-1]; // founder allele
+    if(f!=1 && f!=3) return 0.0;      // founder missing -> no information
+
+    if(f == obs_gen) return log(1.0 - error_prob);
+
+    return log(error_prob); // genotyping error
+}
+
+
+const double RISELF8::step(const int gen_left, const int gen_right, const double rec_frac,
+                            const bool is_x_chr, const bool is_female,
+                            const IntegerVector& cross_info)
+{
+    #ifndef NDEBUG
+    if(!check_geno(gen_left, false, is_x_chr, is_female, cross_info) ||
+       !check_geno(gen_right, false, is_x_chr, is_female, cross_info))
+        throw std::range_error("genotype value not allowed");
+    #endif
+
+    // FIX_ME
+    // oy this is a bit tricky; need to use cross_info
+
+    return(NA_REAL);
+}
+
+const IntegerVector RISELF8::possible_gen(const bool is_x_chr, const bool is_female,
+                                       const IntegerVector& cross_info)
+{
+    int n_geno = 8;
+    IntegerVector result(n_geno);
+
+    for(int i=0; i<n_geno; i++) result[i] = i+1;
+    return result;
+}
+
+const int RISELF8::ngen(const bool is_x_chr)
+{
+    return 8;
+}
+
+const int RISELF8::nalleles()
+{
+    return 8;
+}
+
+
+// check that cross_info conforms to expectation
+const bool RISELF8::check_crossinfo(const IntegerMatrix& cross_info, const bool any_x_chr)
+{
+    bool result = true;
+    const int n_row = cross_info.rows();
+    const int n_col = cross_info.cols();
+    // 8 columns with order of cross
+
+    if(n_col != 8) {
+        result = false;
+        r_message("cross_info not provided, but should 8 columns, indicating the order of the cross");
+        return result;
+    }
+
+    int n_missing=0;
+    int n_invalid=0;
+    for(int i=0; i<n_row; i++) {
+        for(int j=0; j<n_col; j++) {
+            if(cross_info(i,j) == NA_INTEGER) ++n_missing;
+            else if(cross_info(i,j) < 1 || cross_info(i,j)>n_col) ++n_invalid;
+        }
+        // count values 1..ncol
+        IntegerVector counts(n_col);
+        for(int j=0; j<n_col; j++) counts[j] = 0; // zero counts
+        for(int j=0; j<n_col; j++) ++counts[cross_info(i,j)-1]; // count values
+        for(int j=0; j<n_col; j++) {
+            if(counts[j] != 1) n_invalid += abs(counts[j] - 1);
+        }
+    }
+    if(n_missing > 0) {
+        result = false;
+        r_message("cross_info has missing values (it shouldn't)");
+    }
+    if(n_invalid > 0) {
+        result = false;
+        r_message("cross_info has invalid values; each row should be permutation of {1, 2, ..., 8}");
+    }
+
+    return result;
+}
+
+
+// check that founder genotype data has correct no. founders and markers
+const bool RISELF8::check_founder_geno_size(const IntegerMatrix& founder_geno, const int n_markers)
+{
+    bool result=true;
+
+    const int fg_mar = founder_geno.cols();
+    const int fg_f   = founder_geno.rows();
+
+    if(fg_mar != n_markers) {
+        result = false;
+        r_message("founder_geno has incorrect number of markers");
+    }
+
+    if(fg_f != 8) {
+        result = false;
+        r_message("founder_geno should have 8 founders");
+    }
+
+    return result;
+}
+
+// check that founder genotype data has correct values
+const bool RISELF8::check_founder_geno_values(const IntegerMatrix& founder_geno)
+{
+    const int fg_mar = founder_geno.cols();
+    const int fg_f   = founder_geno.rows();
+
+    for(int f=0; f<fg_f; f++) {
+        for(int mar=0; mar<fg_mar; mar++) {
+            int fg = founder_geno(f,mar);
+            if(fg != 0 && fg != 1 && fg != 3) {
+                // at least one invalid value
+                r_message("founder_geno contains invalid values; should be in {0, 1, 3}");
+                return false;
+            }
+        }
+    }
+
+    return true;
+}
+
+const bool RISELF8::need_founder_geno()
+{
+    return true;
+}
+
+// geno_names from allele names
+const std::vector<std::string> RISELF8::geno_names(const std::vector<std::string> alleles,
+                                                const bool is_x_chr)
+{
+    int n_alleles = alleles.size();
+
+    if(alleles.size() < 8)
+        throw std::range_error("alleles must have length 8");
+
+    std::vector<std::string> result(n_alleles);
+
+    for(int i=0; i<n_alleles; i++)
+        result[i] = alleles[i];
+
+    return result;
+}
+
+
+const int RISELF8::nrec(const int gen_left, const int gen_right,
+                         const bool is_x_chr, const bool is_female,
+                         const Rcpp::IntegerVector& cross_info)
+{
+    #ifndef NDEBUG
+    if(!check_geno(gen_left, false, is_x_chr, is_female, cross_info) ||
+       !check_geno(gen_right, false, is_x_chr, is_female, cross_info))
+        throw std::range_error("genotype value not allowed");
+    #endif
+
+    if(gen_left == gen_right) return 0;
+    else return 1;
+}
+
+const double RISELF8::est_rec_frac(const Rcpp::NumericVector& gamma, const bool is_x_chr,
+                                    const Rcpp::IntegerMatrix& cross_info, const int n_gen)
+{
+    // FIX_ME need to implement this
+    return(NA_REAL);
+}
+
+// check whether X chr can be handled
+const bool RISELF8::check_handle_x_chr(const bool any_x_chr)
+{
+    if(any_x_chr) {
+        r_message("X chr ignored for RIL by selfing.");
+        return false;
+    }
+
+    return true; // most crosses can handle the X chr
+}

--- a/src/cross_riself8.h
+++ b/src/cross_riself8.h
@@ -1,0 +1,54 @@
+// 8-way RIL by selfing QTLCross class (for HMM)
+
+#ifndef CROSS_RISELF8_H
+#define CROSS_RISELF8_H
+
+#include <Rcpp.h>
+#include "cross.h"
+
+class RISELF8 : public QTLCross
+{
+ public:
+    RISELF8(){
+        crosstype = "riself8";
+        phase_known_crosstype = "riself8";
+    };
+    ~RISELF8(){};
+
+    const bool check_geno(const int gen, const bool is_observed_value,
+                          const bool is_x_chr, const bool is_female, const Rcpp::IntegerVector& cross_info);
+
+    const double init(const int true_gen,
+                      const bool is_x_chr, const bool is_female, const Rcpp::IntegerVector& cross_info);
+    const double emit(const int obs_gen, const int true_gen, const double error_prob,
+                      const Rcpp::IntegerVector& founder_geno, const bool is_x_chr,
+                      const bool is_female, const Rcpp::IntegerVector& cross_info);
+    const double step(const int gen_left, const int gen_right, const double rec_frac,
+                      const bool is_x_chr, const bool is_female, const Rcpp::IntegerVector& cross_info);
+
+    const Rcpp::IntegerVector possible_gen(const bool is_x_chr, const bool is_female, const Rcpp::IntegerVector& cross_info);
+
+    const int ngen(const bool is_x_chr);
+    const int nalleles();
+
+    const bool check_crossinfo(const Rcpp::IntegerMatrix& cross_info, const bool any_x_chr);
+
+    const bool check_founder_geno_size(const Rcpp::IntegerMatrix& founder_geno, const int n_markers);
+    const bool check_founder_geno_values(const Rcpp::IntegerMatrix& founder_geno);
+    const bool need_founder_geno();
+
+    const std::vector<std::string> geno_names(const std::vector<std::string> alleles, const bool is_x_chr);
+
+    const int nrec(const int gen_left, const int gen_right,
+                   const bool is_x_chr, const bool is_female,
+                   const Rcpp::IntegerVector& cross_info);
+
+    const double est_rec_frac(const Rcpp::NumericVector& gamma, const bool is_x_chr,
+                              const Rcpp::IntegerMatrix& cross_info, const int n_gen);
+
+    // check whether X chr can be handled
+    const bool check_handle_x_chr(const bool any_x_chr);
+
+};
+
+#endif // CROSS_RISELF8_H

--- a/src/cross_util.cpp
+++ b/src/cross_util.cpp
@@ -137,3 +137,27 @@ const std::vector<std::string> mpp_geno_names(const std::vector<std::string> all
         return result;
     }
 }
+
+// For vector of founder indices (cross info), create the reverse index
+// with the reverse indices starting at 0
+// (2,3,1,4) -> (2,0,1,3)
+// (2,4,3,1) -> (3,0,2,1)
+// (7,8,3,5,4,1,6,2) -> (5,7,2,4,3,6,0,1)
+//
+// [[Rcpp::export]]
+IntegerVector reverse_index_founders(IntegerVector cross_info)
+{
+    const int n = cross_info.size();
+    IntegerVector result(n);
+
+    for(int i=0; i<n; i++) {
+        const int f = cross_info[i];
+        #ifndef NDEBUG
+        if(f < 1 || f > n)
+            throw std::range_error("cross_info has values out of range");
+        #endif
+        result[f-1] = i;
+    }
+
+    return(result);
+}

--- a/src/cross_util.h
+++ b/src/cross_util.h
@@ -19,4 +19,12 @@ bool mpp_is_het(const int true_gen, const int n_alleles, const bool phase_known)
 const std::vector<std::string> mpp_geno_names(const std::vector<std::string> alleles,
                                               const bool is_x_chr);
 
+// For vector of founder indices (cross info), create the reverse index
+// with the reverse indices starting at 0
+// (2,3,1,4) -> (2,0,1,3)
+// (2,4,3,1) -> (3,0,2,1)
+// (7,8,3,5,4,1,6,2) -> (5,7,2,4,3,6,0,1)
+//
+Rcpp::IntegerVector reverse_index_founders(Rcpp::IntegerVector cross_info);
+
 #endif // CROSS_UTIL_H

--- a/tests/testthat/test-cross_util.R
+++ b/tests/testthat/test-cross_util.R
@@ -101,3 +101,11 @@ test_that("mpp_is_het works for 8 alleles, phase known", {
         }
     }
 })
+
+test_that("reverse_index_founders works", {
+
+    expect_equal(reverse_index_founders(c(2,3,1,4)), c(2,0,1,3))
+    expect_equal(reverse_index_founders(c(2,4,3,1)), c(3,0,2,1))
+    expect_equal(reverse_index_founders(c(7,8,3,5,4,1,6,2)), c(5,7,2,4,3,6,0,1))
+
+})

--- a/tests/testthat/test-hmmbasic-ail.R
+++ b/tests/testthat/test-hmmbasic-ail.R
@@ -294,3 +294,23 @@ test_that("geno_names works", {
     expect_equal(geno_names("ail", c("B", "R"), FALSE), c("BB", "BR", "RR"))
     expect_equal(geno_names("ail", c("B", "R"), TRUE), c("BB", "BR", "RR", "BY", "RY"))
 })
+
+
+test_that("nrec works", {
+
+    # autosome genotypes = 1:3
+    expected <- rbind(c(0,1,2), c(1,0,1), c(2,1,0))
+    for(i in 1:3)
+        for(j in 1:3) {
+            expect_equal(test_nrec("ail", i, j, FALSE, FALSE, 0), expected[i,j])
+            expect_equal(test_nrec("ail", i, j, TRUE, TRUE, 0), expected[i,j])
+            expect_equal(test_nrec("ail", i, j, TRUE, TRUE, 0), expected[i,j])
+        }
+
+    # X chromosome male
+    expected <- rbind(c(0,1), c(1,0))
+    for(i in 1:2)
+        for(j in 1:2)
+            expect_equal(test_nrec("ail", i+3, j+3, TRUE, FALSE, 0), expected[i,j])
+
+})

--- a/tests/testthat/test-hmmbasic-ailpk.R
+++ b/tests/testthat/test-hmmbasic-ailpk.R
@@ -321,3 +321,26 @@ test_that("phase-known AIL step works", {
 
 
 })
+
+test_that("nrec works for AIL-pk", {
+
+    # autosome or female X chr
+    expected <- rbind(c(0,1,1,2),
+                      c(1,0,2,1),
+                      c(1,2,0,1),
+                      c(2,1,1,0))
+    for(i in 1:4) {
+        for(j in 1:4) {
+            expect_equal(test_nrec("ailpk", i, j, FALSE, FALSE, c(20,0)), expected[i,j])
+            expect_equal(test_nrec("ailpk", i, j, TRUE, TRUE, c(20,0)), expected[i,j])
+        }
+    }
+
+    # male X chr
+    for(i in 1:2) {
+        for(j in 1:2) {
+            expect_equal(test_nrec("ailpk", i, j, TRUE, FALSE, c(20,0)), expected[i,j])
+        }
+    }
+
+})

--- a/tests/testthat/test-hmmbasic-do.R
+++ b/tests/testthat/test-hmmbasic-do.R
@@ -237,3 +237,38 @@ test_that("geno_names works", {
     expect_equal(geno_names("do", LETTERS[1:8], FALSE), auto)
     expect_equal(geno_names("do", LETTERS[1:8], TRUE), X)
 })
+
+test_that("nrec works", {
+
+    # X chr male
+    for(i in 36+(1:8)) {
+        for(j in 36+(1:8)) {
+            expect_equal(test_nrec("do", i, j, TRUE, FALSE, 0), as.numeric(i!=j))
+            # hs should be the same, too
+            expect_equal(test_nrec("hs", i, j, TRUE, FALSE, 0), as.numeric(i!=j))
+        }
+    }
+
+    # autosome or X chr female
+    g <- sapply(1:36, mpp_decode_geno, 8, FALSE)
+    expected <- resultA <- resultX <- matrix(ncol=ncol(g), nrow=ncol(g))
+    resultAhs <- resultXhs <- resultA
+    for(i in 1:ncol(g)) {
+        for(j in 1:ncol(g)) {
+            if((g[1,i] == g[1,j] && g[2,i]==g[2,j]) ||
+               (g[1,i] == g[2,j] && g[2,i]==g[1,j])) expected[i,j] <- 0
+            else if(g[1,i] != g[1,j] && g[2,i]!=g[2,j] &&
+                    g[1,i] != g[2,j] && g[2,i]!=g[1,j]) expected[i,j] <- 2
+            else expected[i,j] <- 1
+
+            resultA[i,j] <- test_nrec("do", i, j, FALSE, FALSE, 0)
+            resultX[i,j] <- test_nrec("do", i, j, TRUE, TRUE, 0)
+            resultAhs[i,j] <- test_nrec("hs", i, j, FALSE, FALSE, 0)
+            resultXhs[i,j] <- test_nrec("hs", i, j, TRUE, TRUE, 0)
+        }
+    }
+    expect_equal(resultA, expected)
+    expect_equal(resultX, expected)
+    expect_equal(resultAhs, expected)
+    expect_equal(resultXhs, expected)
+})

--- a/tests/testthat/test-hmmbasic-dopk.R
+++ b/tests/testthat/test-hmmbasic-dopk.R
@@ -216,3 +216,37 @@ test_that("Phase-known DO step works", {
     }
 
 })
+
+test_that("nrec works", {
+
+    # X chr male
+    for(i in 64+(1:8)) {
+        for(j in 64+(1:8)) {
+            expect_equal(test_nrec("dopk", i, j, TRUE, FALSE, 0), as.numeric(i!=j))
+            expect_equal(test_nrec("hspk", i, j, TRUE, FALSE, 0), as.numeric(i!=j))
+        }
+    }
+
+    # autosome or X chr female
+    g <- sapply(1:64, mpp_decode_geno, 8, TRUE)
+    expected <- resultA <- resultX <- matrix(ncol=ncol(g), nrow=ncol(g))
+    resultAhs <- resultXhs <- resultA
+    for(i in 1:ncol(g)) {
+        for(j in 1:ncol(g)) {
+            if((g[1,i] == g[1,j] && g[2,i]==g[2,j]) ||
+               (g[1,i] == g[2,j] && g[2,i]==g[1,j])) expected[i,j] <- 0
+            else if(g[1,i] != g[1,j] && g[2,i]!=g[2,j] &&
+                    g[1,i] != g[2,j] && g[2,i]!=g[1,j]) expected[i,j] <- 2
+            else expected[i,j] <- 1
+
+            resultA[i,j] <- test_nrec("dopk", i, j, FALSE, FALSE, 0)
+            resultX[i,j] <- test_nrec("dopk", i, j, TRUE, TRUE, 0)
+            resultAhs[i,j] <- test_nrec("hspk", i, j, FALSE, FALSE, 0)
+            resultXhs[i,j] <- test_nrec("hspk", i, j, TRUE, TRUE, 0)
+        }
+    }
+    expect_equal(resultA, expected)
+    expect_equal(resultX, expected)
+    expect_equal(resultAhs, expected)
+    expect_equal(resultXhs, expected)
+})

--- a/tests/testthat/test-hmmbasic-f2.R
+++ b/tests/testthat/test-hmmbasic-f2.R
@@ -226,3 +226,37 @@ test_that("geno_names works", {
     expect_equal(geno_names("f2", c("B", "R"), FALSE), c("BB", "BR", "RR"))
     expect_equal(geno_names("f2", c("B", "R"), TRUE), c("BB", "BR", "RB", "RR", "BY", "RY"))
 })
+
+test_that("nrec works", {
+
+    # autosome genotypes = 1:3
+    expected <- rbind(c(0,1,2), c(1,0,1), c(2,1,0))
+    for(i in 1:3)
+        for(j in 1:3)
+            expect_equal(test_nrec("f2", i, j, FALSE, FALSE, 0), expected[i,j])
+
+    # X chromosome female, forward
+    expected <- rbind(c(0,1), c(1,0))
+    for(i in 1:2)
+        for(j in 1:2)
+            expect_equal(test_nrec("f2", i, j, TRUE, TRUE, 0), expected[i,j])
+
+    # X chromosome female, reverse
+    expected <- rbind(c(0,1), c(1,0))
+    for(i in 1:2)
+        for(j in 1:2)
+            expect_equal(test_nrec("f2", i+2, j+2, TRUE, TRUE, 1), expected[i,j])
+
+    # X chromosome male
+    expected <- rbind(c(0,1), c(1,0))
+    for(i in 1:2)
+        for(j in 1:2)
+            expect_equal(test_nrec("f2", i+4, j+4, TRUE, FALSE, 0), expected[i,j])
+
+    # X chromosome male
+    expected <- rbind(c(0,1), c(1,0))
+    for(i in 1:2)
+        for(j in 1:2)
+            expect_equal(test_nrec("f2", i+4, j+4, TRUE, FALSE, 1), expected[i,j])
+
+})

--- a/tests/testthat/test-hmmbasic-riself4-8-16.R
+++ b/tests/testthat/test-hmmbasic-riself4-8-16.R
@@ -72,6 +72,30 @@ test_that("riself8 step works", {
         expect_equal(result, log(expected))
     }
 
+    # test with different order of founders
+    forder <- c(3, 8, 5, 2, 1, 7, 6, 4)
+    forder_rev <- c(5,4,1,8,3,7,6,2)
+
+    for(rf in c(0.01, 0.1, 0.45)) {
+        expected <- matrix(rf/16/(1+2*rf), ncol=8, nrow=8)
+        diag(expected) <- (1-rf)^2/8/(1+2*rf)
+        block <- list(c(1,2), c(3,4), c(5,6), c(7,8))
+        for(i in seq_along(block)) {
+            b <- block[[i]]
+            expected[b[1],b[2]] <- expected[b[2],b[1]] <- rf*(1-rf)/8/(1+2*rf)
+        }
+        expected <- expected[forder_rev, forder_rev]
+
+        result <- matrix(ncol=8, nrow=8)
+        for(i in 1:8) {
+            for(j in 1:8) {
+                result[i,j] <- test_step("riself8", i, j, rf, FALSE, FALSE, forder)
+            }
+        }
+
+        expect_equal(result, log(expected))
+    }
+
 })
 
 
@@ -79,7 +103,7 @@ test_that("riself8 step works", {
 
 test_that("riself16 step works", {
 
-    for(rf in 0.2) {#c(0.01, 0.1, 0.45)) {
+    for(rf in c(0.01, 0.1, 0.45)) {
         expected <- matrix(rf/64/(1+2*rf), ncol=16, nrow=16)
         expected[1:4,1:4] <- expected[5:8,5:8] <-
             expected[9:12,9:12] <- expected[13:16,13:16] <- rf*(1-rf)/32/(1+2*rf)
@@ -94,6 +118,31 @@ test_that("riself16 step works", {
         for(i in 1:16) {
             for(j in 1:16) {
                 result[i,j] <- test_step("riself16", i, j, rf, FALSE, FALSE, 1:16)
+            }
+        }
+
+        expect_equal(result, log(expected))
+    }
+
+    # test with founders in a different order
+    forder <- c(12, 5, 15, 13, 14, 1, 2, 3, 9, 10, 6, 11, 8, 4, 16, 7)
+    forder_rev <- c(6,7,8,14,2,11,16,13,9,10,12,1,4,5,3,15)
+    for(rf in c(0.01, 0.1, 0.45)) {
+        expected <- matrix(rf/64/(1+2*rf), ncol=16, nrow=16)
+        expected[1:4,1:4] <- expected[5:8,5:8] <-
+            expected[9:12,9:12] <- expected[13:16,13:16] <- rf*(1-rf)/32/(1+2*rf)
+        diag(expected) <- (1-rf)^3/16/(1+2*rf)
+        block <- list(c(1,2), c(3,4), c(5,6), c(7,8),c(9,10),c(11,12),c(13,14),c(15,16))
+        for(i in seq_along(block)) {
+            b <- block[[i]]
+            expected[b[1],b[2]] <- expected[b[2],b[1]] <- rf*(1-rf)^2/16/(1+2*rf)
+        }
+        expected <- expected[forder_rev, forder_rev]
+
+        result <- matrix(ncol=16, nrow=16)
+        for(i in 1:16) {
+            for(j in 1:16) {
+                result[i,j] <- test_step("riself16", i, j, rf, FALSE, FALSE, forder)
             }
         }
 

--- a/tests/testthat/test-hmmbasic-riself4-8-16.R
+++ b/tests/testthat/test-hmmbasic-riself4-8-16.R
@@ -1,0 +1,136 @@
+context("basic HMM functions in 4-, 8-, and 16-way RIL by selfing")
+
+test_that("riself4-8-16 n_gen, n_alleles work", {
+
+    expect_equal(nalleles("riself4"), 4)
+    expect_equal(nalleles("riself8"), 8)
+    expect_equal(nalleles("riself16"), 16)
+
+    expect_equal(test_ngen("riself4", FALSE), 4)
+    expect_equal(test_ngen("riself8", FALSE), 8)
+    expect_equal(test_ngen("riself16", FALSE), 16)
+
+})
+
+test_that("riself4-8-16 possible_gen work", {
+
+    expect_equal(test_possible_gen("riself4", FALSE, FALSE, 1:4), 1:4)
+    expect_equal(test_possible_gen("riself8", FALSE, FALSE, 1:8), 1:8)
+    expect_equal(test_possible_gen("riself16", FALSE, FALSE, 1:16), 1:16)
+
+})
+
+# FIX_ME: test check_geno
+
+test_that("riself4-8-16 init work", {
+
+    expect_equal( sapply(1:4, function(i) test_init("riself4", i, FALSE, FALSE, 1:4)), log(rep(1/4, 4)) )
+    expect_equal( sapply(1:8, function(i) test_init("riself8", i, FALSE, FALSE, 1:8)), log(rep(1/8, 8)) )
+    expect_equal( sapply(1:16, function(i) test_init("riself16", i, FALSE, FALSE, 1:16)), log(rep(1/16, 16)) )
+
+})
+
+# FIX_ME: test emit
+
+test_that("riself4 step works", {
+
+    for(rf in c(0.01, 0.1, 0.45)) {
+        expected <- matrix(rf/4/(1+2*rf), ncol=4, nrow=4)
+        diag(expected) <- (1-rf)/4/(1+2*rf)
+
+        result <- matrix(ncol=4, nrow=4)
+        for(i in 1:4) {
+            for(j in 1:4) {
+                result[i,j] <- test_step("riself4", i, j, rf, FALSE, FALSE, 1:4)
+            }
+        }
+
+        expect_equal(result, log(expected))
+    }
+
+})
+
+
+test_that("riself8 step works", {
+
+    for(rf in c(0.01, 0.1, 0.45)) {
+        expected <- matrix(rf/16/(1+2*rf), ncol=8, nrow=8)
+        diag(expected) <- (1-rf)^2/8/(1+2*rf)
+        block <- list(c(1,2), c(3,4), c(5,6), c(7,8))
+        for(i in seq_along(block)) {
+            b <- block[[i]]
+            expected[b[1],b[2]] <- expected[b[2],b[1]] <- rf*(1-rf)/8/(1+2*rf)
+        }
+
+        result <- matrix(ncol=8, nrow=8)
+        for(i in 1:8) {
+            for(j in 1:8) {
+                result[i,j] <- test_step("riself8", i, j, rf, FALSE, FALSE, 1:8)
+            }
+        }
+
+        expect_equal(result, log(expected))
+    }
+
+})
+
+
+
+
+test_that("riself16 step works", {
+
+    for(rf in 0.2) {#c(0.01, 0.1, 0.45)) {
+        expected <- matrix(rf/64/(1+2*rf), ncol=16, nrow=16)
+        expected[1:4,1:4] <- expected[5:8,5:8] <-
+            expected[9:12,9:12] <- expected[13:16,13:16] <- rf*(1-rf)/32/(1+2*rf)
+        diag(expected) <- (1-rf)^3/16/(1+2*rf)
+        block <- list(c(1,2), c(3,4), c(5,6), c(7,8),c(9,10),c(11,12),c(13,14),c(15,16))
+        for(i in seq_along(block)) {
+            b <- block[[i]]
+            expected[b[1],b[2]] <- expected[b[2],b[1]] <- rf*(1-rf)^2/16/(1+2*rf)
+        }
+
+        result <- matrix(ncol=16, nrow=16)
+        for(i in 1:16) {
+            for(j in 1:16) {
+                result[i,j] <- test_step("riself16", i, j, rf, FALSE, FALSE, 1:16)
+            }
+        }
+
+        expect_equal(result, log(expected))
+    }
+
+})
+
+
+
+
+test_that("riself4-8-16 geno_names work", {
+
+    expect_equal( geno_names("riself4", LETTERS[5:8], FALSE), LETTERS[5:8] )
+    expect_equal( geno_names("riself8", LETTERS[2:9], FALSE), LETTERS[2:9] )
+    expect_equal( geno_names("riself16", LETTERS[11:26], FALSE), LETTERS[11:26] )
+
+})
+
+test_that("riself4-8-16 nrec work", {
+
+    x <- matrix(ncol=16, nrow=16)
+    x <- matrix(as.numeric(col(x) != row(x)), ncol=16)
+
+    res4 <- matrix(ncol=4, nrow=4)
+    res8 <- matrix(ncol=8, nrow=8)
+    res16 <- matrix(ncol=16, nrow=16)
+    for(i in 1:16) {
+        for(j in 1:16) {
+            if(i<5 && j<5) res4[i,j] <- test_nrec("riself4", i, j, FALSE, FALSE, 1:4)
+            if(i<9 && j<9) res8[i,j] <- test_nrec("riself8", i, j, FALSE, FALSE, 1:8)
+            res16[i,j] <- test_nrec("riself16", i, j, FALSE, FALSE, 1:16)
+        }
+    }
+
+    expect_equal( res4, x[1:4,1:4])
+    expect_equal( res8, x[1:8,1:8])
+    expect_equal( res16, x)
+
+})


### PR DESCRIPTION
- Added crosstypes `"riself4"`, `"riself8"`, and `"riself16"`, for 2<sup>n</sup>-way RIL by selfing

- Fixed bugs in `read_cross2` for case that data has a physical map but not a genetic map

- Added argument `overwrite` (default is `FALSE`) in `write_control_file`, so you don't have to remove the file separately (though the default is still to stop with an error if the file exists).