### PR TITLE
Implemented cross types risib4 and risib8

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,5 +1,5 @@
 Package: qtl2geno
-Version: 0.5-15
+Version: 0.5-16
 Date: 2017-04-14
 Title: Treatment of Marker Genotypes for QTL Experiments
 Description: Functions to calculate QTL genotype probabilities, impute

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,3 +1,11 @@
+## qtl2geno 0.5-16 (2017-04-14)
+
+### New features
+
+- Implemented new cross types `"risib4"` and `"risib8"`. The latter
+  corresponds to the Collaborative Cross.
+
+
 ## qtl2geno 0.5-15 (2017-04-14)
 
 ### New features

--- a/src/cross.cpp
+++ b/src/cross.cpp
@@ -27,6 +27,8 @@
 #include "cross_riself4.h"
 #include "cross_riself8.h"
 #include "cross_riself16.h"
+#include "cross_risib4.h"
+#include "cross_risib8.h"
 
 QTLCross* QTLCross::Create(const String& crosstype)
 {
@@ -47,6 +49,8 @@ QTLCross* QTLCross::Create(const String& crosstype)
     if(crosstype=="riself4") return new RISELF4();
     if(crosstype=="riself8") return new RISELF8();
     if(crosstype=="riself16") return new RISELF16();
+    if(crosstype=="risib4") return new RISIB4();
+    if(crosstype=="risib8") return new RISIB8();
 
     throw std::range_error("cross type not yet supported.");
     return NULL;

--- a/src/cross.cpp
+++ b/src/cross.cpp
@@ -41,16 +41,16 @@ QTLCross* QTLCross::Create(const String& crosstype)
     if(crosstype=="haploid") return new HAPLOID();
     if(crosstype=="ail")     return new AIL();
     if(crosstype=="ailpk")   return new AILPK();
-    if(crosstype=="do")     return new DO();
-    if(crosstype=="dopk")   return new DOPK();
-    if(crosstype=="dof1")   return new DOF1();
-    if(crosstype=="hs")     return new HS();
-    if(crosstype=="hspk")   return new HSPK();
+    if(crosstype=="do")      return new DO();
+    if(crosstype=="dopk")    return new DOPK();
+    if(crosstype=="dof1")    return new DOF1();
+    if(crosstype=="hs")      return new HS();
+    if(crosstype=="hspk")    return new HSPK();
     if(crosstype=="riself4") return new RISELF4();
     if(crosstype=="riself8") return new RISELF8();
     if(crosstype=="riself16") return new RISELF16();
-    if(crosstype=="risib4") return new RISIB4();
-    if(crosstype=="risib8") return new RISIB8();
+    if(crosstype=="risib4")  return new RISIB4();
+    if(crosstype=="risib8")  return new RISIB8();
 
     throw std::range_error("cross type not yet supported.");
     return NULL;

--- a/src/cross_ail.cpp
+++ b/src/cross_ail.cpp
@@ -416,7 +416,7 @@ const bool AIL::check_crossinfo(const IntegerMatrix& cross_info, const bool any_
 
     if(n_col == 0) {
         result = false;
-        r_message("cross_info not provided, but should at least have one column, with no. generations");
+        r_message("cross_info should at least have one column, with no. generations");
         return result;
     }
 

--- a/src/cross_ailpk.cpp
+++ b/src/cross_ailpk.cpp
@@ -504,7 +504,7 @@ const bool AILPK::check_crossinfo(const IntegerMatrix& cross_info, const bool an
 
     if(n_col == 0) {
         result = false;
-        r_message("cross_info not provided, but should at least have one column, with no. generations");
+        r_message("cross_info should have at least one column, with no. generations");
         return result;
     }
 

--- a/src/cross_do.cpp
+++ b/src/cross_do.cpp
@@ -288,7 +288,7 @@ const bool DO::check_crossinfo(const IntegerMatrix& cross_info, const bool any_x
 
     if(n_col == 0) {
         result = false;
-        r_message("cross_info not provided, but should at least one column, with no. generations");
+        r_message("cross_info should have at least one column, with no. generations");
         return result;
     }
 

--- a/src/cross_dof1.cpp
+++ b/src/cross_dof1.cpp
@@ -258,7 +258,7 @@ const bool DOF1::check_crossinfo(const IntegerMatrix& cross_info, const bool any
 
     if(n_col == 0) {
         result = false;
-        r_message("cross_info not provided, but should at least one column, with no. generations");
+        r_message("cross_info should have at least one column, with no. generations");
         return result;
     }
 

--- a/src/cross_dopk.cpp
+++ b/src/cross_dopk.cpp
@@ -328,7 +328,7 @@ const bool DOPK::check_crossinfo(const IntegerMatrix& cross_info, const bool any
 
     if(n_col == 0) {
         result = false;
-        r_message("cross_info not provided, but should at least one column, with no. generations");
+        r_message("cross_info should have at least one column, with no. generations");
         return result;
     }
 

--- a/src/cross_hs.cpp
+++ b/src/cross_hs.cpp
@@ -287,7 +287,7 @@ const bool HS::check_crossinfo(const IntegerMatrix& cross_info, const bool any_x
 
     if(n_col == 0) {
         result = false;
-        r_message("cross_info not provided, but should at least one column, with no. generations");
+        r_message("cross_info should have at least one column, with no. generations");
         return result;
     }
 

--- a/src/cross_hspk.cpp
+++ b/src/cross_hspk.cpp
@@ -328,7 +328,7 @@ const bool HSPK::check_crossinfo(const IntegerMatrix& cross_info, const bool any
 
     if(n_col == 0) {
         result = false;
-        r_message("cross_info not provided, but should at least one column, with no. generations");
+        r_message("cross_info should have at least one column, with no. generations");
         return result;
     }
 

--- a/src/cross_riself16.cpp
+++ b/src/cross_riself16.cpp
@@ -123,7 +123,7 @@ const bool RISELF16::check_crossinfo(const IntegerMatrix& cross_info, const bool
 
     if(n_col != 16) {
         result = false;
-        r_message("cross_info not provided, but should have 16 columns, indicating the order of the cross");
+        r_message("cross_info should have 16 columns, indicating the order of the cross");
         return result;
     }
 

--- a/src/cross_riself16.cpp
+++ b/src/cross_riself16.cpp
@@ -205,15 +205,15 @@ const bool RISELF16::need_founder_geno()
 const std::vector<std::string> RISELF16::geno_names(const std::vector<std::string> alleles,
                                                 const bool is_x_chr)
 {
-    int n_alleles = alleles.size();
-
     if(alleles.size() < 16)
         throw std::range_error("alleles must have length 16");
+
+    const int n_alleles = 16;
 
     std::vector<std::string> result(n_alleles);
 
     for(int i=0; i<n_alleles; i++)
-        result[i] = alleles[i];
+        result[i] = alleles[i] + alleles[i];
 
     return result;
 }

--- a/src/cross_riself16.cpp
+++ b/src/cross_riself16.cpp
@@ -123,7 +123,7 @@ const bool RISELF16::check_crossinfo(const IntegerMatrix& cross_info, const bool
 
     if(n_col != 16) {
         result = false;
-        r_message("cross_info not provided, but should 16 columns, indicating the order of the cross");
+        r_message("cross_info not provided, but should have 16 columns, indicating the order of the cross");
         return result;
     }
 
@@ -240,8 +240,8 @@ const double RISELF16::est_rec_frac(const Rcpp::NumericVector& gamma, const bool
     int n_gen_sq = n_gen*n_gen;
 
     #ifndef NDEBUG
-    if(cross_info.rows() != 8) // incorrect number of founders
-        throw std::range_error("cross_info should contain 8 founders");
+    if(cross_info.rows() != 16) // incorrect number of founders
+        throw std::range_error("cross_info should contain 16 founders");
     #endif
 
     double u=0.0, v=0.0, w=0.0, y=0.0; // counts of the four different patterns of 2-locus genotypes

--- a/src/cross_riself4.cpp
+++ b/src/cross_riself4.cpp
@@ -107,7 +107,7 @@ const bool RISELF4::check_crossinfo(const IntegerMatrix& cross_info, const bool 
 
     if(n_col != 4) {
         result = false;
-        r_message("cross_info not provided, but should 4 columns, indicating the order of the cross");
+        r_message("cross_info not provided, but should have 4 columns, indicating the order of the cross");
         return result;
     }
 

--- a/src/cross_riself4.cpp
+++ b/src/cross_riself4.cpp
@@ -107,7 +107,7 @@ const bool RISELF4::check_crossinfo(const IntegerMatrix& cross_info, const bool 
 
     if(n_col != 4) {
         result = false;
-        r_message("cross_info not provided, but should have 4 columns, indicating the order of the cross");
+        r_message("cross_info should have 4 columns, indicating the order of the cross");
         return result;
     }
 

--- a/src/cross_riself4.cpp
+++ b/src/cross_riself4.cpp
@@ -189,15 +189,15 @@ const bool RISELF4::need_founder_geno()
 const std::vector<std::string> RISELF4::geno_names(const std::vector<std::string> alleles,
                                                 const bool is_x_chr)
 {
-    int n_alleles = alleles.size();
-
     if(alleles.size() < 4)
         throw std::range_error("alleles must have length 4");
+
+    const int n_alleles = 4;
 
     std::vector<std::string> result(n_alleles);
 
     for(int i=0; i<n_alleles; i++)
-        result[i] = alleles[i];
+        result[i] = alleles[i] + alleles[i];
 
     return result;
 }

--- a/src/cross_riself8.cpp
+++ b/src/cross_riself8.cpp
@@ -122,7 +122,7 @@ const bool RISELF8::check_crossinfo(const IntegerMatrix& cross_info, const bool 
 
     if(n_col != 8) {
         result = false;
-        r_message("cross_info not provided, but should 8 columns, indicating the order of the cross");
+        r_message("cross_info not provided, but should have 8 columns, indicating the order of the cross");
         return result;
     }
 

--- a/src/cross_riself8.cpp
+++ b/src/cross_riself8.cpp
@@ -204,15 +204,15 @@ const bool RISELF8::need_founder_geno()
 const std::vector<std::string> RISELF8::geno_names(const std::vector<std::string> alleles,
                                                 const bool is_x_chr)
 {
-    int n_alleles = alleles.size();
-
     if(alleles.size() < 8)
         throw std::range_error("alleles must have length 8");
+
+    const int n_alleles = 8;
 
     std::vector<std::string> result(n_alleles);
 
     for(int i=0; i<n_alleles; i++)
-        result[i] = alleles[i];
+        result[i] = alleles[i] + alleles[i];
 
     return result;
 }

--- a/src/cross_riself8.cpp
+++ b/src/cross_riself8.cpp
@@ -122,7 +122,7 @@ const bool RISELF8::check_crossinfo(const IntegerMatrix& cross_info, const bool 
 
     if(n_col != 8) {
         result = false;
-        r_message("cross_info not provided, but should have 8 columns, indicating the order of the cross");
+        r_message("cross_info should have 8 columns, indicating the order of the cross");
         return result;
     }
 

--- a/src/cross_risib4.cpp
+++ b/src/cross_risib4.cpp
@@ -282,10 +282,11 @@ const NumericVector RISIB4::est_map2(const IntegerMatrix& genotypes,
                                 tol, verbose);
     }
 
-    return est_map2_founderorder(this->crosstype,
-                                 genotypes, founder_geno,
-                                 is_X_chr, is_female, cross_info,
-                                 cross_group, unique_cross_group,
-                                 rec_frac, error_prob, max_iterations,
-                                 tol, verbose);
+    // X chromosome: need to use the lowmem version
+    return est_map2_lowmem(this->crosstype,
+                           genotypes, founder_geno,
+                           is_X_chr, is_female, cross_info,
+                           cross_group, unique_cross_group,
+                           rec_frac, error_prob, max_iterations,
+                           tol, verbose);
 }

--- a/src/cross_risib4.cpp
+++ b/src/cross_risib4.cpp
@@ -235,20 +235,6 @@ const std::vector<std::string> RISIB4::geno_names(const std::vector<std::string>
 }
 
 
-const int RISIB4::nrec(const int gen_left, const int gen_right,
-                         const bool is_x_chr, const bool is_female,
-                         const Rcpp::IntegerVector& cross_info)
-{
-    #ifndef NDEBUG
-    if(!check_geno(gen_left, false, is_x_chr, is_female, cross_info) ||
-       !check_geno(gen_right, false, is_x_chr, is_female, cross_info))
-        throw std::range_error("genotype value not allowed");
-    #endif
-
-    if(gen_left == gen_right) return 0;
-    else return 1;
-}
-
 const double RISIB4::est_rec_frac(const Rcpp::NumericVector& gamma, const bool is_x_chr,
                                     const Rcpp::IntegerMatrix& cross_info, const int n_gen)
 {

--- a/src/cross_risib4.cpp
+++ b/src/cross_risib4.cpp
@@ -139,7 +139,7 @@ const bool RISIB4::check_crossinfo(const IntegerMatrix& cross_info, const bool a
 
     if(n_col != 4) {
         result = false;
-        r_message("cross_info not provided, but should have 4 columns, indicating the order of the cross");
+        r_message("cross_info should have 4 columns, indicating the order of the cross");
         return result;
     }
 

--- a/src/cross_risib4.cpp
+++ b/src/cross_risib4.cpp
@@ -1,0 +1,305 @@
+// 4-way RIL by sib-mating QTLCross class (for HMM)
+
+#include "cross_risib4.h"
+#include <math.h>
+#include <Rcpp.h>
+#include "cross.h"
+#include "cross_util.h"
+#include "cross_do_util.h"
+#include "r_message.h"
+
+enum gen {A=1, H=2, B=3, notA=5, notB=4};
+
+const bool RISIB4::check_geno(const int gen, const bool is_observed_value,
+                                const bool is_x_chr, const bool is_female,
+                                const IntegerVector& cross_info)
+{
+    // allow any value 0-5 for observed
+    if(is_observed_value) {
+        if(gen==0 || gen==A || gen==H || gen==B ||
+           gen==notA || gen==notB) return true;
+        else return false;
+    }
+
+    if(!is_x_chr) { // autosome
+        const int n_geno = 4;
+        if(gen>= 1 && gen <= n_geno) return true;
+    }
+    else { // X chromosome
+        if(gen >= 1 && gen <= 4 && gen != cross_info[3]) return true;
+    }
+
+    return false; // otherwise a problem
+}
+
+const double RISIB4::init(const int true_gen,
+                            const bool is_x_chr, const bool is_female,
+                            const IntegerVector& cross_info)
+{
+    #ifndef NDEBUG
+    if(!check_geno(true_gen, false, is_x_chr, is_female, cross_info))
+        throw std::range_error("genotype value not allowed");
+    #endif
+
+    if(!is_x_chr) { // autosome
+        return -log(4.0);
+    }
+    else { // X chromosome Pr(A)=Pr(B)=Pr(C)=1/3
+        return -log(3.0);
+    }
+}
+
+const double RISIB4::emit(const int obs_gen, const int true_gen, const double error_prob,
+                            const IntegerVector& founder_geno, const bool is_x_chr,
+                            const bool is_female, const IntegerVector& cross_info)
+{
+    #ifndef NDEBUG
+    if(!check_geno(true_gen, false, is_x_chr, is_female, cross_info))
+        throw std::range_error("genotype value not allowed");
+    #endif
+
+    if(obs_gen==0) return 0.0; // missing
+
+    int f = founder_geno[true_gen-1]; // founder allele
+    if(f!=1 && f!=3) return 0.0;      // founder missing -> no information
+
+    if(f == obs_gen) return log(1.0 - error_prob);
+
+    return log(error_prob); // genotyping error
+}
+
+
+const double RISIB4::step(const int gen_left, const int gen_right, const double rec_frac,
+                            const bool is_x_chr, const bool is_female,
+                            const IntegerVector& cross_info)
+{
+    #ifndef NDEBUG
+    if(!check_geno(gen_left, false, is_x_chr, is_female, cross_info) ||
+       !check_geno(gen_right, false, is_x_chr, is_female, cross_info))
+        throw std::range_error("genotype value not allowed");
+    #endif
+
+    if(!is_x_chr) {
+        // equations are from Broman (2005) Genetics 169:1133-1146
+        //    doi:10.1534/genetics.104.035212
+        //    see top equation in right column on page 1137
+        if(gen_left == gen_right)
+            return -log(1.0 + 6.0 * rec_frac);
+
+        return log(2.0) + log(rec_frac) - log(1.0 + 6.0 * rec_frac);
+    }
+    else { // 1/3
+        if(gen_left == gen_right)
+            return - log(1.0 + 4.0 * rec_frac);
+
+        return log(2.0) + log(rec_frac) - log(1.0 + 4.0 * rec_frac);
+    }
+}
+
+const IntegerVector RISIB4::possible_gen(const bool is_x_chr, const bool is_female,
+                                       const IntegerVector& cross_info)
+{
+    if(!is_x_chr) { // autosome
+        int n_geno = 4;
+        IntegerVector result(n_geno);
+
+        for(int i=0; i<n_geno; i++) result[i] = i+1;
+        return result;
+    }
+    else { // X chromosome
+        int n_geno = 3;
+        IntegerVector result(n_geno);
+
+        for(int i=0; i<n_geno; i++) result[i] = cross_info[i];
+        return result;
+    }
+}
+
+const int RISIB4::ngen(const bool is_x_chr)
+{
+    return 4;
+}
+
+const int RISIB4::nalleles()
+{
+    return 4;
+}
+
+
+// check that cross_info conforms to expectation
+const bool RISIB4::check_crossinfo(const IntegerMatrix& cross_info, const bool any_x_chr)
+{
+    bool result = true;
+    const int n_row = cross_info.rows();
+    const int n_col = cross_info.cols();
+    // 16 columns with order of cross
+
+    if(n_col != 4) {
+        result = false;
+        r_message("cross_info not provided, but should have 4 columns, indicating the order of the cross");
+        return result;
+    }
+
+    int n_missing=0;
+    int n_invalid=0;
+    for(int i=0; i<n_row; i++) {
+        for(int j=0; j<n_col; j++) {
+            if(cross_info(i,j) == NA_INTEGER) ++n_missing;
+            else if(cross_info(i,j) < 1 || cross_info(i,j)>n_col) ++n_invalid;
+        }
+        // count values 1..ncol
+        IntegerVector counts(n_col);
+        for(int j=0; j<n_col; j++) counts[j] = 0; // zero counts
+        for(int j=0; j<n_col; j++) ++counts[cross_info(i,j)-1]; // count values
+        for(int j=0; j<n_col; j++) {
+            if(counts[j] != 1) n_invalid += abs(counts[j] - 1);
+        }
+    }
+    if(n_missing > 0) {
+        result = false;
+        r_message("cross_info has missing values (it shouldn't)");
+    }
+    if(n_invalid > 0) {
+        result = false;
+        r_message("cross_info has invalid values; each row should be permutation of {1, 2, ..., 4}");
+    }
+
+    return result;
+}
+
+
+// check that founder genotype data has correct no. founders and markers
+const bool RISIB4::check_founder_geno_size(const IntegerMatrix& founder_geno, const int n_markers)
+{
+    bool result=true;
+
+    const int fg_mar = founder_geno.cols();
+    const int fg_f   = founder_geno.rows();
+
+    if(fg_mar != n_markers) {
+        result = false;
+        r_message("founder_geno has incorrect number of markers");
+    }
+
+    if(fg_f != 4) {
+        result = false;
+        r_message("founder_geno should have 4 founders");
+    }
+
+    return result;
+}
+
+// check that founder genotype data has correct values
+const bool RISIB4::check_founder_geno_values(const IntegerMatrix& founder_geno)
+{
+    const int fg_mar = founder_geno.cols();
+    const int fg_f   = founder_geno.rows();
+
+    for(int f=0; f<fg_f; f++) {
+        for(int mar=0; mar<fg_mar; mar++) {
+            int fg = founder_geno(f,mar);
+            if(fg != 0 && fg != 1 && fg != 3) {
+                // at least one invalid value
+                r_message("founder_geno contains invalid values; should be in {0, 1, 3}");
+                return false;
+            }
+        }
+    }
+
+    return true;
+}
+
+const bool RISIB4::need_founder_geno()
+{
+    return true;
+}
+
+// geno_names from allele names
+const std::vector<std::string> RISIB4::geno_names(const std::vector<std::string> alleles,
+                                                const bool is_x_chr)
+{
+    int n_alleles = alleles.size();
+
+    if(alleles.size() < 4)
+        throw std::range_error("alleles must have length 4");
+
+    std::vector<std::string> result(n_alleles);
+
+    for(int i=0; i<n_alleles; i++)
+        result[i] = alleles[i];
+
+    return result;
+}
+
+
+const int RISIB4::nrec(const int gen_left, const int gen_right,
+                         const bool is_x_chr, const bool is_female,
+                         const Rcpp::IntegerVector& cross_info)
+{
+    #ifndef NDEBUG
+    if(!check_geno(gen_left, false, is_x_chr, is_female, cross_info) ||
+       !check_geno(gen_right, false, is_x_chr, is_female, cross_info))
+        throw std::range_error("genotype value not allowed");
+    #endif
+
+    if(gen_left == gen_right) return 0;
+    else return 1;
+}
+
+const double RISIB4::est_rec_frac(const Rcpp::NumericVector& gamma, const bool is_x_chr,
+                                    const Rcpp::IntegerMatrix& cross_info, const int n_gen)
+{
+    int n_ind = cross_info.cols();
+    int n_gen_sq = n_gen*n_gen;
+
+    R = QTLCross::est_rec_frac(gamma, is_x_chr, cross_info, n_gen);
+
+    if(is_x_chr) { // X chromosome: solve R=4r/(1+4r) for r
+        return R/4.0/(1.0-R);
+    }
+    else { // autosome: solve R=6r/(1+6r) for r
+        return R/6.0/(1.0-R);
+    }
+}
+
+// check whether X chr can be handled
+const bool RISIB4::check_handle_x_chr(const bool any_x_chr)
+{
+    return true; // most crosses can handle the X chr
+}
+
+const NumericVector RISIB4::est_map2(const IntegerMatrix& genotypes,
+                                     const IntegerMatrix& founder_geno,
+                                     const bool is_X_chr,
+                                     const LogicalVector& is_female,
+                                     const IntegerMatrix& cross_info,
+                                     const IntegerVector& cross_group,
+                                     const IntegerVector& unique_cross_group,
+                                     const NumericVector& rec_frac,
+                                     const double error_prob,
+                                     const int max_iterations,
+                                     const double tol,
+                                     const bool verbose)
+{
+    if(!is_X_chr) { // autosome; can ignore founder order
+        const int n_ind = cross_group.size();
+        Rcpp::IntegerVector one_group(n_ind);
+        for(int i=0; i<n_ind; i++) one_group[i] = 0;
+        Rcpp::IntegerVector one_unique_group(1);
+        one_unique_group[0] = 0;
+
+        return est_map2_grouped(this->crosstype,
+                                genotypes, founder_geno,
+                                is_X_chr, is_female, cross_info,
+                                one_group, one_unique_group,
+                                rec_frac, error_prob, max_iterations,
+                                tol, verbose);
+    }
+
+    return est_map2_founderorder(this->crosstype,
+                                 genotypes, founder_geno,
+                                 is_X_chr, is_female, cross_info,
+                                 cross_group, unique_cross_group,
+                                 rec_frac, error_prob, max_iterations,
+                                 tol, verbose);
+}

--- a/src/cross_risib4.cpp
+++ b/src/cross_risib4.cpp
@@ -252,10 +252,7 @@ const int RISIB4::nrec(const int gen_left, const int gen_right,
 const double RISIB4::est_rec_frac(const Rcpp::NumericVector& gamma, const bool is_x_chr,
                                     const Rcpp::IntegerMatrix& cross_info, const int n_gen)
 {
-    int n_ind = cross_info.cols();
-    int n_gen_sq = n_gen*n_gen;
-
-    R = QTLCross::est_rec_frac(gamma, is_x_chr, cross_info, n_gen);
+    double R = QTLCross::est_rec_frac(gamma, is_x_chr, cross_info, n_gen);
 
     if(is_x_chr) { // X chromosome: solve R=4r/(1+4r) for r
         return R/4.0/(1.0-R);

--- a/src/cross_risib4.cpp
+++ b/src/cross_risib4.cpp
@@ -88,7 +88,10 @@ const double RISIB4::step(const int gen_left, const int gen_right, const double 
 
         return log(2.0) + log(rec_frac) - log(1.0 + 6.0 * rec_frac);
     }
-    else { // 1/3
+    else { // X chromosome
+        // equations are from Broman (2005) Genetics 169:1133-1146
+        //    doi:10.1534/genetics.104.035212
+        //    see right column on page 1136
         if(gen_left == gen_right)
             return - log(1.0 + 4.0 * rec_frac);
 

--- a/src/cross_risib4.cpp
+++ b/src/cross_risib4.cpp
@@ -221,15 +221,15 @@ const bool RISIB4::need_founder_geno()
 const std::vector<std::string> RISIB4::geno_names(const std::vector<std::string> alleles,
                                                 const bool is_x_chr)
 {
-    int n_alleles = alleles.size();
-
     if(alleles.size() < 4)
         throw std::range_error("alleles must have length 4");
+
+    const int n_alleles = 4;
 
     std::vector<std::string> result(n_alleles);
 
     for(int i=0; i<n_alleles; i++)
-        result[i] = alleles[i];
+        result[i] = alleles[i] + alleles[i];
 
     return result;
 }

--- a/src/cross_risib4.h
+++ b/src/cross_risib4.h
@@ -39,10 +39,6 @@ class RISIB4 : public QTLCross
 
     const std::vector<std::string> geno_names(const std::vector<std::string> alleles, const bool is_x_chr);
 
-    const int nrec(const int gen_left, const int gen_right,
-                   const bool is_x_chr, const bool is_female,
-                   const Rcpp::IntegerVector& cross_info);
-
     const double est_rec_frac(const Rcpp::NumericVector& gamma, const bool is_x_chr,
                               const Rcpp::IntegerMatrix& cross_info, const int n_gen);
 

--- a/src/cross_risib4.h
+++ b/src/cross_risib4.h
@@ -1,0 +1,67 @@
+// 4-way RIL by sib-mating QTLCross class (for HMM)
+
+#ifndef CROSS_RISIB4_H
+#define CROSS_RISIB4_H
+
+#include <Rcpp.h>
+#include "cross.h"
+
+class RISIB4 : public QTLCross
+{
+ public:
+    RISIB4(){
+        crosstype = "risib4";
+        phase_known_crosstype = "risib4";
+    };
+    ~RISIB4(){};
+
+    const bool check_geno(const int gen, const bool is_observed_value,
+                          const bool is_x_chr, const bool is_female, const Rcpp::IntegerVector& cross_info);
+
+    const double init(const int true_gen,
+                      const bool is_x_chr, const bool is_female, const Rcpp::IntegerVector& cross_info);
+    const double emit(const int obs_gen, const int true_gen, const double error_prob,
+                      const Rcpp::IntegerVector& founder_geno, const bool is_x_chr,
+                      const bool is_female, const Rcpp::IntegerVector& cross_info);
+    const double step(const int gen_left, const int gen_right, const double rec_frac,
+                      const bool is_x_chr, const bool is_female, const Rcpp::IntegerVector& cross_info);
+
+    const Rcpp::IntegerVector possible_gen(const bool is_x_chr, const bool is_female, const Rcpp::IntegerVector& cross_info);
+
+    const int ngen(const bool is_x_chr);
+    const int nalleles();
+
+    const bool check_crossinfo(const Rcpp::IntegerMatrix& cross_info, const bool any_x_chr);
+
+    const bool check_founder_geno_size(const Rcpp::IntegerMatrix& founder_geno, const int n_markers);
+    const bool check_founder_geno_values(const Rcpp::IntegerMatrix& founder_geno);
+    const bool need_founder_geno();
+
+    const std::vector<std::string> geno_names(const std::vector<std::string> alleles, const bool is_x_chr);
+
+    const int nrec(const int gen_left, const int gen_right,
+                   const bool is_x_chr, const bool is_female,
+                   const Rcpp::IntegerVector& cross_info);
+
+    const double est_rec_frac(const Rcpp::NumericVector& gamma, const bool is_x_chr,
+                              const Rcpp::IntegerMatrix& cross_info, const int n_gen);
+
+    // check whether X chr can be handled
+    const bool check_handle_x_chr(const bool any_x_chr);
+
+    // tailored est_map that pre-calculates transition matrices, etc
+    const Rcpp::NumericVector est_map2(const Rcpp::IntegerMatrix& genotypes,
+                                       const Rcpp::IntegerMatrix& founder_geno,
+                                       const bool is_X_chr,
+                                       const Rcpp::LogicalVector& is_female,
+                                       const Rcpp::IntegerMatrix& cross_info,
+                                       const Rcpp::IntegerVector& cross_group,
+                                       const Rcpp::IntegerVector& unique_cross_group,
+                                       const Rcpp::NumericVector& rec_frac,
+                                       const double error_prob,
+                                       const int max_iterations,
+                                       const double tol,
+                                       const bool verbose);
+};
+
+#endif // CROSS_RISIB4_H

--- a/src/cross_risib8.cpp
+++ b/src/cross_risib8.cpp
@@ -46,7 +46,7 @@ const double RISIB8::init(const int true_gen,
     #endif
 
     if(!is_x_chr) { // autosome
-        return -log(4.0);
+        return -log(8.0);
     }
     else { // X chromosome Pr(A)=Pr(B)=Pr(C)=1/3
         if(true_gen == cross_info[3]) return -log(3.0);

--- a/src/cross_risib8.cpp
+++ b/src/cross_risib8.cpp
@@ -91,7 +91,7 @@ const double RISIB8::step(const int gen_left, const int gen_right, const double 
         if(gen_left == gen_right)
             return log(1.0 - rec_frac) - log(1.0 + 6.0 * rec_frac);
 
-        return log(4.0) + log(rec_frac) - log(1.0 + 6.0 * rec_frac);
+        return log(rec_frac) - log(1.0 + 6.0 * rec_frac);
     }
     else { // X chr; need to use founder order
         // equations are from Broman (2005) Genetics 169:1133-1146

--- a/src/cross_risib8.cpp
+++ b/src/cross_risib8.cpp
@@ -157,7 +157,7 @@ const bool RISIB8::check_crossinfo(const IntegerMatrix& cross_info, const bool a
 
     if(n_col != 8) {
         result = false;
-        r_message("cross_info not provided, but should have 8 columns, indicating the order of the cross");
+        r_message("cross_info should have 8 columns, indicating the order of the cross");
         return result;
     }
 

--- a/src/cross_risib8.cpp
+++ b/src/cross_risib8.cpp
@@ -87,13 +87,16 @@ const double RISIB8::step(const int gen_left, const int gen_right, const double 
     if(!is_x_chr) {
         // equations are from Broman (2005) Genetics 169:1133-1146
         //    doi:10.1534/genetics.104.035212
-        //    see top equation in right column on page 1137
+        //    see bottom equation in right column on page 1137
         if(gen_left == gen_right)
             return log(1.0 - rec_frac) - log(1.0 + 6.0 * rec_frac);
 
         return log(4.0) + log(rec_frac) - log(1.0 + 6.0 * rec_frac);
     }
     else { // X chr; need to use founder order
+        // equations are from Broman (2005) Genetics 169:1133-1146
+        //    doi:10.1534/genetics.104.035212
+        //    see table 4 page 1137
         if(gen_left == gen_right) {
             if(gen_left == cross_info[2])
                 return - log(1.0 + 4.0 * rec_frac);

--- a/src/cross_risib8.cpp
+++ b/src/cross_risib8.cpp
@@ -49,7 +49,7 @@ const double RISIB8::init(const int true_gen,
         return -log(8.0);
     }
     else { // X chromosome Pr(A)=Pr(B)=Pr(C)=1/3
-        if(true_gen == cross_info[3]) return -log(3.0);
+        if(true_gen == cross_info[2]) return -log(3.0);
         else return -log(6.0);
     }
 }

--- a/src/cross_risib8.cpp
+++ b/src/cross_risib8.cpp
@@ -323,10 +323,11 @@ const NumericVector RISIB8::est_map2(const IntegerMatrix& genotypes,
                                 tol, verbose);
     }
 
-    return est_map2_founderorder(this->crosstype,
-                                 genotypes, founder_geno,
-                                 is_X_chr, is_female, cross_info,
-                                 cross_group, unique_cross_group,
-                                 rec_frac, error_prob, max_iterations,
-                                 tol, verbose);
+    // X chromosome: need to use the lowmem version for now
+    return est_map2_lowmem(this->crosstype,
+                           genotypes, founder_geno,
+                           is_X_chr, is_female, cross_info,
+                           cross_group, unique_cross_group,
+                           rec_frac, error_prob, max_iterations,
+                           tol, verbose);
 }

--- a/src/cross_risib8.cpp
+++ b/src/cross_risib8.cpp
@@ -239,15 +239,15 @@ const bool RISIB8::need_founder_geno()
 const std::vector<std::string> RISIB8::geno_names(const std::vector<std::string> alleles,
                                                 const bool is_x_chr)
 {
-    int n_alleles = alleles.size();
-
     if(alleles.size() < 8)
         throw std::range_error("alleles must have length 8");
+
+    const int n_alleles = 8;
 
     std::vector<std::string> result(n_alleles);
 
     for(int i=0; i<n_alleles; i++)
-        result[i] = alleles[i];
+        result[i] = alleles[i] + alleles[i];
 
     return result;
 }

--- a/src/cross_risib8.cpp
+++ b/src/cross_risib8.cpp
@@ -1,0 +1,323 @@
+// 8-way RIL by sib-mating QTLCross class (for HMM)
+
+#include "cross_risib8.h"
+#include <math.h>
+#include <Rcpp.h>
+#include "cross.h"
+#include "cross_util.h"
+#include "cross_do_util.h"
+#include "r_message.h"
+
+enum gen {A=1, H=2, B=3, notA=5, notB=4};
+
+const bool RISIB8::check_geno(const int gen, const bool is_observed_value,
+                                const bool is_x_chr, const bool is_female,
+                                const IntegerVector& cross_info)
+{
+    // allow any value 0-5 for observed
+    if(is_observed_value) {
+        if(gen==0 || gen==A || gen==H || gen==B ||
+           gen==notA || gen==notB) return true;
+        else return false;
+    }
+
+    if(!is_x_chr) { // autosome
+        const int n_geno = 8;
+        if(gen>= 1 && gen <= n_geno) return true;
+    }
+    else { // X chromosome (can be A, B, C, E, F but not D, G, H)
+        if(gen >= 1 && gen <= 8 &&
+           gen != cross_info[3] &&
+           gen != cross_info[6] &&
+           gen != cross_info[7])
+            return true;
+    }
+
+    return false; // otherwise a problem
+}
+
+const double RISIB8::init(const int true_gen,
+                            const bool is_x_chr, const bool is_female,
+                            const IntegerVector& cross_info)
+{
+    #ifndef NDEBUG
+    if(!check_geno(true_gen, false, is_x_chr, is_female, cross_info))
+        throw std::range_error("genotype value not allowed");
+    #endif
+
+    if(!is_x_chr) { // autosome
+        return -log(4.0);
+    }
+    else { // X chromosome Pr(A)=Pr(B)=Pr(C)=1/3
+        if(true_gen == cross_info[3]) return -log(3.0);
+        else return -log(6.0);
+    }
+}
+
+const double RISIB8::emit(const int obs_gen, const int true_gen, const double error_prob,
+                            const IntegerVector& founder_geno, const bool is_x_chr,
+                            const bool is_female, const IntegerVector& cross_info)
+{
+    #ifndef NDEBUG
+    if(!check_geno(true_gen, false, is_x_chr, is_female, cross_info))
+        throw std::range_error("genotype value not allowed");
+    #endif
+
+    if(obs_gen==0) return 0.0; // missing
+
+    int f = founder_geno[true_gen-1]; // founder allele
+    if(f!=1 && f!=3) return 0.0;      // founder missing -> no information
+
+    if(f == obs_gen) return log(1.0 - error_prob);
+
+    return log(error_prob); // genotyping error
+}
+
+
+const double RISIB8::step(const int gen_left, const int gen_right, const double rec_frac,
+                            const bool is_x_chr, const bool is_female,
+                            const IntegerVector& cross_info)
+{
+    #ifndef NDEBUG
+    if(!check_geno(gen_left, false, is_x_chr, is_female, cross_info) ||
+       !check_geno(gen_right, false, is_x_chr, is_female, cross_info))
+        throw std::range_error("genotype value not allowed");
+    #endif
+
+    if(!is_x_chr) {
+        // equations are from Broman (2005) Genetics 169:1133-1146
+        //    doi:10.1534/genetics.104.035212
+        //    see top equation in right column on page 1137
+        if(gen_left == gen_right)
+            return log(1.0 - rec_frac) - log(1.0 + 6.0 * rec_frac);
+
+        return log(4.0) + log(rec_frac) - log(1.0 + 6.0 * rec_frac);
+    }
+    else { // X chr; need to use founder order
+        if(gen_left == gen_right) {
+            if(gen_left == cross_info[2])
+                return - log(1.0 + 4.0 * rec_frac);
+            else
+                return log(1.0 - rec_frac) - log(1.0 + 4.0 * rec_frac);
+        }
+
+        if(gen_right == cross_info[2])
+            return log(2.0) + log(rec_frac) - log(1.0 + 4.0 * rec_frac);
+
+        // otherwise...
+        return log(rec_frac) - log(1.0 + 4.0 * rec_frac);
+    }
+}
+
+const IntegerVector RISIB8::possible_gen(const bool is_x_chr, const bool is_female,
+                                       const IntegerVector& cross_info)
+{
+    if(!is_x_chr) { // autosome
+        int n_geno = 8;
+        IntegerVector result(n_geno);
+
+        for(int i=0; i<n_geno; i++) result[i] = i+1;
+        return result;
+    }
+    else { // X chromosome
+        int n_geno = 5;
+        IntegerVector result(n_geno);
+
+        result[0] = cross_info[0];
+        result[1] = cross_info[1];
+        result[2] = cross_info[2];
+        result[3] = cross_info[4];
+        result[4] = cross_info[5];
+
+        return result;
+    }
+}
+
+const int RISIB8::ngen(const bool is_x_chr)
+{
+    return 8;
+}
+
+const int RISIB8::nalleles()
+{
+    return 8;
+}
+
+
+// check that cross_info conforms to expectation
+const bool RISIB8::check_crossinfo(const IntegerMatrix& cross_info, const bool any_x_chr)
+{
+    bool result = true;
+    const int n_row = cross_info.rows();
+    const int n_col = cross_info.cols();
+    // 16 columns with order of cross
+
+    if(n_col != 8) {
+        result = false;
+        r_message("cross_info not provided, but should have 8 columns, indicating the order of the cross");
+        return result;
+    }
+
+    int n_missing=0;
+    int n_invalid=0;
+    for(int i=0; i<n_row; i++) {
+        for(int j=0; j<n_col; j++) {
+            if(cross_info(i,j) == NA_INTEGER) ++n_missing;
+            else if(cross_info(i,j) < 1 || cross_info(i,j)>n_col) ++n_invalid;
+        }
+        // count values 1..ncol
+        IntegerVector counts(n_col);
+        for(int j=0; j<n_col; j++) counts[j] = 0; // zero counts
+        for(int j=0; j<n_col; j++) ++counts[cross_info(i,j)-1]; // count values
+        for(int j=0; j<n_col; j++) {
+            if(counts[j] != 1) n_invalid += abs(counts[j] - 1);
+        }
+    }
+    if(n_missing > 0) {
+        result = false;
+        r_message("cross_info has missing values (it shouldn't)");
+    }
+    if(n_invalid > 0) {
+        result = false;
+        r_message("cross_info has invalid values; each row should be permutation of {1, 2, ..., 4}");
+    }
+
+    return result;
+}
+
+
+// check that founder genotype data has correct no. founders and markers
+const bool RISIB8::check_founder_geno_size(const IntegerMatrix& founder_geno, const int n_markers)
+{
+    bool result=true;
+
+    const int fg_mar = founder_geno.cols();
+    const int fg_f   = founder_geno.rows();
+
+    if(fg_mar != n_markers) {
+        result = false;
+        r_message("founder_geno has incorrect number of markers");
+    }
+
+    if(fg_f != 8) {
+        result = false;
+        r_message("founder_geno should have 4 founders");
+    }
+
+    return result;
+}
+
+// check that founder genotype data has correct values
+const bool RISIB8::check_founder_geno_values(const IntegerMatrix& founder_geno)
+{
+    const int fg_mar = founder_geno.cols();
+    const int fg_f   = founder_geno.rows();
+
+    for(int f=0; f<fg_f; f++) {
+        for(int mar=0; mar<fg_mar; mar++) {
+            int fg = founder_geno(f,mar);
+            if(fg != 0 && fg != 1 && fg != 3) {
+                // at least one invalid value
+                r_message("founder_geno contains invalid values; should be in {0, 1, 3}");
+                return false;
+            }
+        }
+    }
+
+    return true;
+}
+
+const bool RISIB8::need_founder_geno()
+{
+    return true;
+}
+
+// geno_names from allele names
+const std::vector<std::string> RISIB8::geno_names(const std::vector<std::string> alleles,
+                                                const bool is_x_chr)
+{
+    int n_alleles = alleles.size();
+
+    if(alleles.size() < 8)
+        throw std::range_error("alleles must have length 8");
+
+    std::vector<std::string> result(n_alleles);
+
+    for(int i=0; i<n_alleles; i++)
+        result[i] = alleles[i];
+
+    return result;
+}
+
+
+const int RISIB8::nrec(const int gen_left, const int gen_right,
+                         const bool is_x_chr, const bool is_female,
+                         const Rcpp::IntegerVector& cross_info)
+{
+    #ifndef NDEBUG
+    if(!check_geno(gen_left, false, is_x_chr, is_female, cross_info) ||
+       !check_geno(gen_right, false, is_x_chr, is_female, cross_info))
+        throw std::range_error("genotype value not allowed");
+    #endif
+
+    if(gen_left == gen_right) return 0;
+    else return 1;
+}
+
+const double RISIB8::est_rec_frac(const Rcpp::NumericVector& gamma, const bool is_x_chr,
+                                    const Rcpp::IntegerMatrix& cross_info, const int n_gen)
+{
+    int n_ind = cross_info.cols();
+    int n_gen_sq = n_gen*n_gen;
+
+    R = QTLCross::est_rec_frac(gamma, is_x_chr, cross_info, n_gen);
+
+    if(is_x_chr) { // X chromosome: ... trickier
+        return R/4.0/(1.0-R);
+    }
+    else { // autosome: solve R=7r/(1+6r) for r
+        return R / (7.0 - 6.0 * R);
+    }
+}
+
+// check whether X chr can be handled
+const bool RISIB8::check_handle_x_chr(const bool any_x_chr)
+{
+    return true; // most crosses can handle the X chr
+}
+
+const NumericVector RISIB8::est_map2(const IntegerMatrix& genotypes,
+                                     const IntegerMatrix& founder_geno,
+                                     const bool is_X_chr,
+                                     const LogicalVector& is_female,
+                                     const IntegerMatrix& cross_info,
+                                     const IntegerVector& cross_group,
+                                     const IntegerVector& unique_cross_group,
+                                     const NumericVector& rec_frac,
+                                     const double error_prob,
+                                     const int max_iterations,
+                                     const double tol,
+                                     const bool verbose)
+{
+    if(!is_X_chr) { // autosome; can ignore founder order
+        const int n_ind = cross_group.size();
+        Rcpp::IntegerVector one_group(n_ind);
+        for(int i=0; i<n_ind; i++) one_group[i] = 0;
+        Rcpp::IntegerVector one_unique_group(1);
+        one_unique_group[0] = 0;
+
+        return est_map2_grouped(this->crosstype,
+                                genotypes, founder_geno,
+                                is_X_chr, is_female, cross_info,
+                                one_group, one_unique_group,
+                                rec_frac, error_prob, max_iterations,
+                                tol, verbose);
+    }
+
+    return est_map2_founderorder(this->crosstype,
+                                 genotypes, founder_geno,
+                                 is_X_chr, is_female, cross_info,
+                                 cross_group, unique_cross_group,
+                                 rec_frac, error_prob, max_iterations,
+                                 tol, verbose);
+}

--- a/src/cross_risib8.cpp
+++ b/src/cross_risib8.cpp
@@ -253,20 +253,6 @@ const std::vector<std::string> RISIB8::geno_names(const std::vector<std::string>
 }
 
 
-const int RISIB8::nrec(const int gen_left, const int gen_right,
-                         const bool is_x_chr, const bool is_female,
-                         const Rcpp::IntegerVector& cross_info)
-{
-    #ifndef NDEBUG
-    if(!check_geno(gen_left, false, is_x_chr, is_female, cross_info) ||
-       !check_geno(gen_right, false, is_x_chr, is_female, cross_info))
-        throw std::range_error("genotype value not allowed");
-    #endif
-
-    if(gen_left == gen_right) return 0;
-    else return 1;
-}
-
 const double RISIB8::est_rec_frac(const Rcpp::NumericVector& gamma, const bool is_x_chr,
                                     const Rcpp::IntegerMatrix& cross_info, const int n_gen)
 {

--- a/src/cross_risib8.h
+++ b/src/cross_risib8.h
@@ -39,10 +39,6 @@ class RISIB8 : public QTLCross
 
     const std::vector<std::string> geno_names(const std::vector<std::string> alleles, const bool is_x_chr);
 
-    const int nrec(const int gen_left, const int gen_right,
-                   const bool is_x_chr, const bool is_female,
-                   const Rcpp::IntegerVector& cross_info);
-
     const double est_rec_frac(const Rcpp::NumericVector& gamma, const bool is_x_chr,
                               const Rcpp::IntegerMatrix& cross_info, const int n_gen);
 

--- a/src/cross_risib8.h
+++ b/src/cross_risib8.h
@@ -1,0 +1,67 @@
+// 8-way RIL by sib-mating QTLCross class (for HMM)
+
+#ifndef CROSS_RISIB8_H
+#define CROSS_RISIB8_H
+
+#include <Rcpp.h>
+#include "cross.h"
+
+class RISIB8 : public QTLCross
+{
+ public:
+    RISIB8(){
+        crosstype = "risib8";
+        phase_known_crosstype = "risib8";
+    };
+    ~RISIB8(){};
+
+    const bool check_geno(const int gen, const bool is_observed_value,
+                          const bool is_x_chr, const bool is_female, const Rcpp::IntegerVector& cross_info);
+
+    const double init(const int true_gen,
+                      const bool is_x_chr, const bool is_female, const Rcpp::IntegerVector& cross_info);
+    const double emit(const int obs_gen, const int true_gen, const double error_prob,
+                      const Rcpp::IntegerVector& founder_geno, const bool is_x_chr,
+                      const bool is_female, const Rcpp::IntegerVector& cross_info);
+    const double step(const int gen_left, const int gen_right, const double rec_frac,
+                      const bool is_x_chr, const bool is_female, const Rcpp::IntegerVector& cross_info);
+
+    const Rcpp::IntegerVector possible_gen(const bool is_x_chr, const bool is_female, const Rcpp::IntegerVector& cross_info);
+
+    const int ngen(const bool is_x_chr);
+    const int nalleles();
+
+    const bool check_crossinfo(const Rcpp::IntegerMatrix& cross_info, const bool any_x_chr);
+
+    const bool check_founder_geno_size(const Rcpp::IntegerMatrix& founder_geno, const int n_markers);
+    const bool check_founder_geno_values(const Rcpp::IntegerMatrix& founder_geno);
+    const bool need_founder_geno();
+
+    const std::vector<std::string> geno_names(const std::vector<std::string> alleles, const bool is_x_chr);
+
+    const int nrec(const int gen_left, const int gen_right,
+                   const bool is_x_chr, const bool is_female,
+                   const Rcpp::IntegerVector& cross_info);
+
+    const double est_rec_frac(const Rcpp::NumericVector& gamma, const bool is_x_chr,
+                              const Rcpp::IntegerMatrix& cross_info, const int n_gen);
+
+    // check whether X chr can be handled
+    const bool check_handle_x_chr(const bool any_x_chr);
+
+    // tailored est_map that pre-calculates transition matrices, etc
+    const Rcpp::NumericVector est_map2(const Rcpp::IntegerMatrix& genotypes,
+                                       const Rcpp::IntegerMatrix& founder_geno,
+                                       const bool is_X_chr,
+                                       const Rcpp::LogicalVector& is_female,
+                                       const Rcpp::IntegerMatrix& cross_info,
+                                       const Rcpp::IntegerVector& cross_group,
+                                       const Rcpp::IntegerVector& unique_cross_group,
+                                       const Rcpp::NumericVector& rec_frac,
+                                       const double error_prob,
+                                       const int max_iterations,
+                                       const double tol,
+                                       const bool verbose);
+};
+
+#endif // CROSS_RISIB8_H

--- a/tests/testthat/test-hmmbasic-riself4-8-16.R
+++ b/tests/testthat/test-hmmbasic-riself4-8-16.R
@@ -156,9 +156,9 @@ test_that("riself16 step works", {
 
 test_that("riself4-8-16 geno_names work", {
 
-    expect_equal( geno_names("riself4", LETTERS[5:8], FALSE), LETTERS[5:8] )
-    expect_equal( geno_names("riself8", LETTERS[2:9], FALSE), LETTERS[2:9] )
-    expect_equal( geno_names("riself16", LETTERS[11:26], FALSE), LETTERS[11:26] )
+    expect_equal( geno_names("riself4", LETTERS[5:8], FALSE), paste0(LETTERS[5:8], LETTERS[5:8]) )
+    expect_equal( geno_names("riself8", LETTERS[2:9], FALSE), paste0(LETTERS[2:9], LETTERS[2:9]) )
+    expect_equal( geno_names("riself16", LETTERS[11:26], FALSE), paste0(LETTERS[11:26], LETTERS[11:26]) )
 
 })
 

--- a/tests/testthat/test-hmmbasic-risib4-8.R
+++ b/tests/testthat/test-hmmbasic-risib4-8.R
@@ -1,0 +1,122 @@
+context("basic HMM functions in 4- and 8-way RIL by sib-mating")
+
+test_that("risib4-8 n_gen, n_alleles work", {
+
+    expect_equal(nalleles("risib4"), 4)
+    expect_equal(nalleles("risib8"), 8)
+
+    expect_equal(test_ngen("risib4", FALSE), 4)
+    expect_equal(test_ngen("risib8", FALSE), 8)
+
+    # X chromosome
+    expect_equal(test_ngen("risib4", TRUE), 4)
+    expect_equal(test_ngen("risib8", TRUE), 8)
+
+})
+
+test_that("risib4-8 possible_gen work", {
+
+    expect_equal(test_possible_gen("risib4", FALSE, FALSE, 1:4), 1:4)
+    expect_equal(test_possible_gen("risib8", FALSE, FALSE, 1:8), 1:8)
+
+    # X chr
+    expect_equal(test_possible_gen("risib4", TRUE, FALSE, 1:4), 1:3)
+    expect_equal(test_possible_gen("risib8", TRUE, FALSE, 1:8), c(1:3,5:6))
+
+    # X chr, different cross order
+    expect_equal(test_possible_gen("risib4", TRUE, FALSE, c(3,4,1,2)), c(3,4,1))
+    expect_equal(test_possible_gen("risib8", TRUE, FALSE, c(4,5,1,3,2,7,8,6)), c(4,5,1,2,7))
+
+    # one more time
+    expect_equal(test_possible_gen("risib4", TRUE, FALSE, c(2,1,4,3)), c(2,1,4))
+    expect_equal(test_possible_gen("risib8", TRUE, FALSE, c(1,5,6,8,4,2,7,3)), c(1,5,6,4,2))
+
+})
+
+# FIX_ME: test check_geno
+
+test_that("risib4-8 init work", {
+
+    expect_equal( sapply(1:4, function(i) test_init("risib4", i, FALSE, FALSE, 1:4)), log(rep(1/4, 4)) )
+    expect_equal( sapply(1:8, function(i) test_init("risib8", i, FALSE, FALSE, 1:8)), log(rep(1/8, 8)) )
+
+    # X chromosome
+    expect_equal( sapply(1:3, function(i) test_init("risib4", i, TRUE, FALSE, 1:4)), log(rep(1/3, 3)) )
+    expect_equal( sapply(c(1:3,5,6), function(i) test_init("risib8", i, TRUE, FALSE, 1:8)), log(c(1,1,2,1,1)/6) )
+
+    # X chromosoem, different order
+    expect_equal( sapply(c(3,4,1), function(i) test_init("risib4", i, TRUE, FALSE, c(3,4,1,2))), log(rep(1/3, 3)) )
+    expect_equal( sapply(c(4,5,1,2,7), function(i) test_init("risib8", i, TRUE, FALSE, c(4,5,1,3,2,7,8,6))), log(c(1,1,2,1,1)/6) )
+
+    # one more time
+    expect_equal( sapply(c(1,2,4), function(i) test_init("risib4", i, TRUE, FALSE, c(2,1,4,3))), log(rep(1/3, 3)) )
+    expect_equal( sapply(c(1,5,6,4,2), function(i) test_init("risib8", i, TRUE, FALSE, c(1,5,6,8,4,2,7,3))), log(c(1,1,2,1,1)/6) )
+
+})
+
+# FIX_ME: test emit
+
+test_that("risib4 step works for autosome", {
+
+    for(rf in c(0.01, 0.1, 0.45)) {
+        expected <- matrix(rf*2/(1+6*rf), ncol=4, nrow=4)
+        diag(expected) <- 1/(1+6*rf)
+
+        result <- matrix(ncol=4, nrow=4)
+        for(i in 1:4) {
+            for(j in 1:4) {
+                result[i,j] <- test_step("risib4", i, j, rf, FALSE, FALSE, 1:4)
+            }
+        }
+
+        expect_equal(result, log(expected))
+    }
+
+})
+
+
+test_that("risib8 step works for autosome", {
+
+    for(rf in c(0.01, 0.1, 0.45)) {
+        expected <- matrix(rf/(1+6*rf), ncol=8, nrow=8)
+        diag(expected) <- (1-rf)/(1+6*rf)
+
+        result <- matrix(ncol=8, nrow=8)
+        for(i in 1:8) {
+            for(j in 1:8) {
+                result[i,j] <- test_step("risib8", i, j, rf, FALSE, FALSE, 1:8)
+            }
+        }
+
+        expect_equal(result, log(expected))
+    }
+
+})
+
+
+
+test_that("risib4-8 geno_names work", {
+
+    expect_equal( geno_names("risib4", LETTERS[5:8], FALSE), paste0(LETTERS[5:8], LETTERS[5:8]) )
+    expect_equal( geno_names("risib8", LETTERS[2:9], FALSE), paste0(LETTERS[2:9], LETTERS[2:9]) )
+
+})
+
+test_that("risib4-8 nrec work", {
+
+    x <- matrix(ncol=8, nrow=8)
+    x <- matrix(as.numeric(col(x) != row(x)), ncol=8)
+
+    res4 <- matrix(ncol=4, nrow=4)
+    res8 <- matrix(ncol=8, nrow=8)
+    for(i in 1:8) {
+        for(j in 1:8) {
+            if(i<5 && j<5) res4[i,j] <- test_nrec("risib4", i, j, FALSE, FALSE, 1:4)
+            if(i<9 && j<9) res8[i,j] <- test_nrec("risib8", i, j, FALSE, FALSE, 1:8)
+        }
+    }
+
+    expect_equal( res4, x[1:4,1:4])
+    expect_equal( res8, x)
+
+})


### PR DESCRIPTION
Implemented HMM code for cross types `"risib4"` and `"risib8"`, 4- and 8-way recombinant inbred lines by sibling mating. The latter is the mouse "[Collaborative Cross](https://www.ncbi.nlm.nih.gov/pubmed/15514660)".

Also, for cross types `"riself4"`, `"riself8"`, and `"riself16"`, changed `geno_names()` to return genotype names like `"AA"` rather than just `"A"`.