### PR TITLE
Fix bugs in read_cross2 + have est_map give warning if doesn't converge

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: qtl2geno
-Version: 0.5-16
-Date: 2017-04-16
+Version: 0.5-17
+Date: 2017-04-17
 Title: Treatment of Marker Genotypes for QTL Experiments
 Description: Functions to calculate QTL genotype probabilities, impute
     QTL genotypes, and estimate genetic maps. Part of R/qtl2, a

--- a/NEWS.md
+++ b/NEWS.md
@@ -12,6 +12,11 @@
   multiple JSON or multiple YAML files. If there's both a YAML and a
   JSON file, the YAML file is used and a warning is issued.
 
+## Minor changes
+
+- `est_map` now gives a warning if it reaches the maximum number of
+  iterations without converging.
+
 
 ## qtl2geno 0.5-16 (2017-04-16)
 

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,3 +1,18 @@
+## qtl2geno 0.5-17 (2017-04-17)
+
+### Bug fixes
+
+- `read_cross2` now unzips a `.zip` file to a separate directory, to
+  avoid possibility of clashing of multiple sets of files.
+
+- `read_cross2` will now ignore any JSON or YAML files in the `.zip`
+  file that have the pattern `__MACOSX/._*`.
+
+- `read_cross2` will stop with an error if a `.zip` file contains
+  multiple JSON or multiple YAML files. If there's both a YAML and a
+  JSON file, the YAML file is used and a warning is issued.
+
+
 ## qtl2geno 0.5-16 (2017-04-16)
 
 ### New features

--- a/R/read_cross2.R
+++ b/R/read_cross2.R
@@ -65,6 +65,8 @@ function(file, quiet=TRUE)
             file <- grep("\\.yaml$", unzipped_files, value=TRUE)
             if(length(file) > 1)
                 stop("The zip file contains multiple yaml files")
+            if(any(grepl("\\.json$", unzipped_files)))
+                warning("The zip file contains both YAML and JSON files; using the YAML file.")
         }
         else if(any(grepl("\\.json$", unzipped_files))) {
             file <- grep("\\.json$", unzipped_files, value=TRUE)

--- a/R/read_cross2.R
+++ b/R/read_cross2.R
@@ -58,12 +58,12 @@ function(file, quiet=TRUE)
             unlink(dir, recursive=TRUE)
         }, add=TRUE)
         if(any(grepl("\\.yaml$", unzipped_files))) {
-            file <- unzipped_files[grep("\\.yaml$", unzipped_files)]
+            file <- grep("\\.yaml$", unzipped_files, value=TRUE)
             if(length(file) > 1)
                 stop("The zip file contains multiple yaml files")
         }
         else if(any(grepl("\\.json$", unzipped_files))) {
-            file <- unzipped_files[grep("\\.json$", unzipped_files)]
+            file <- grep("\\.json$", unzipped_files, value=TRUE)
             if(length(file) > 1)
                 stop("The zip file contains multiple json files")
         }

--- a/R/read_cross2.R
+++ b/R/read_cross2.R
@@ -61,6 +61,9 @@ function(file, quiet=TRUE)
             unlink(dir, recursive=TRUE)
         }, add=TRUE)
 
+        # ignore "__MACOSX/._" files
+        unzipped_files <- grep("__MACOSX/._", unzipped_files, fixed=TRUE, invert=TRUE, value=TRUE)
+
         if(any(grepl("\\.yaml$", unzipped_files))) {
             file <- grep("\\.yaml$", unzipped_files, value=TRUE)
             if(length(file) > 1)

--- a/R/read_cross2.R
+++ b/R/read_cross2.R
@@ -40,7 +40,7 @@ read_cross2 <-
 function(file, quiet=TRUE)
 {
     if(length(grep("\\.zip$", file)) > 0) { # zip file
-        dir <- tempdir()
+        dir <- file.path(tempdir(), paste0("qtl2_", paste(sample(c(letters, 0:9), 15, replace=TRUE), collapse="")))
         if(is_web_file(file)) {
             tmpfile <- tempfile()
             if(!quiet) message(" - downloading ", file, "\n       to ", tmpfile)

--- a/R/read_cross2.R
+++ b/R/read_cross2.R
@@ -40,7 +40,8 @@ read_cross2 <-
 function(file, quiet=TRUE)
 {
     if(length(grep("\\.zip$", file)) > 0) { # zip file
-        dir <- file.path(tempdir(), paste0("qtl2_", paste(sample(c(letters, 0:9), 15, replace=TRUE), collapse="")))
+        dir <- qtl2_temp_dir()
+
         if(is_web_file(file)) {
             tmpfile <- tempfile()
             if(!quiet) message(" - downloading ", file, "\n       to ", tmpfile)
@@ -53,10 +54,13 @@ function(file, quiet=TRUE)
         file <- path.expand(file)
         stop_if_no_file(file)
         unzipped_files <- utils::unzip(file, exdir=dir)
-        on.exit({ # clean up when done
+
+        # remove temporary directory on exit
+        on.exit({
             if(!quiet) message(" - cleaning up")
             unlink(dir, recursive=TRUE)
         }, add=TRUE)
+
         if(any(grepl("\\.yaml$", unzipped_files))) {
             file <- grep("\\.yaml$", unzipped_files, value=TRUE)
             if(length(file) > 1)
@@ -727,4 +731,13 @@ reorder_map_table <-
     pos <- suppressWarnings( as.numeric(map_tab[,pos_col]) )
 
     map_tab[ order(chr, pos, seq_len(nrow(map_tab))), , drop=FALSE]
+}
+
+# create unique temporary directory name
+qtl2_temp_dir <-
+    function(n_letters=15, initial_bit="qtl2")
+{
+    file.path(tempdir(),
+              paste0(initial_bit, "_", paste(sample(c(letters, 0:9), n_letters, replace=TRUE), collapse="")) )
+
 }

--- a/R/read_cross2.R
+++ b/R/read_cross2.R
@@ -53,20 +53,23 @@ function(file, quiet=TRUE)
         file <- path.expand(file)
         stop_if_no_file(file)
         unzipped_files <- utils::unzip(file, exdir=dir)
+        on.exit({ # clean up when done
+            if(!quiet) message(" - cleaning up")
+            unlink(dir, recursive=TRUE)
+        }, add=TRUE)
         if(any(grepl("\\.yaml$", unzipped_files))) {
             file <- unzipped_files[grep("\\.yaml$", unzipped_files)]
+            if(length(file) > 1)
+                stop("The zip file contains multiple yaml files")
         }
         else if(any(grepl("\\.json$", unzipped_files))) {
             file <- unzipped_files[grep("\\.json$", unzipped_files)]
+            if(length(file) > 1)
+                stop("The zip file contains multiple json files")
         }
         else {
             stop('No ".yaml" or ".json" control file found')
         }
-
-        on.exit({ # clean up when done
-            if(!quiet) message(" - cleaning up")
-            unlink(unzipped_files)
-        }, add=TRUE)
     }
 
     # directory containing the data

--- a/src/hmm_estmap.cpp
+++ b/src/hmm_estmap.cpp
@@ -6,6 +6,7 @@
 #include "cross.h"
 #include "hmm_util.h"
 #include "hmm_forwback.h"
+#include "r_message.h"
 
 // re-estimate inter-marker recombination fractions
 // [[Rcpp::export(".est_map")]]
@@ -74,6 +75,7 @@ NumericVector est_map(const String& crosstype,
     int n_gen_sq_times_n_ind = n_gen_sq * n_ind;
     NumericVector full_gamma(n_gen_sq_times_n_ind * n_rf);
 
+    bool converged = false; // flag for convergence
     for(int it=0; it<max_iterations; it++) {
 
         // zero the full_gamma array
@@ -147,7 +149,7 @@ NumericVector est_map(const String& crosstype,
         }
 
         // check convergence
-        bool converged = true;
+        converged = true;
         for(int pos=0; pos<n_rf; pos++) {
             if(fabs(prev_rec_frac[pos] - cur_rec_frac[pos]) > tol*(cur_rec_frac[pos]+tol*100.0)) {
                 converged = false;
@@ -159,6 +161,9 @@ NumericVector est_map(const String& crosstype,
 
         prev_rec_frac = clone(cur_rec_frac);
     } // end loop over iterations
+
+    if(!converged)
+        r_warning("est_map reaching maximum iterations without converging");
 
     // calculate log likelihood
     double loglik = 0.0;

--- a/src/hmm_estmap2.cpp
+++ b/src/hmm_estmap2.cpp
@@ -13,6 +13,7 @@
 #include "hmm_util.h"
 #include "hmm_forwback2.h"
 #include "hmm_estmap.h"
+#include "r_message.h"
 #include "cross_util.h"
 
 // re-estimate inter-marker recombination fractions
@@ -179,6 +180,7 @@ NumericVector est_map2_grouped(const String crosstype,
         n_poss_gen[i] = poss_gen[i].size();
     }
 
+    bool converged = false; // flag for convergence
     for(int it=0; it<max_iterations; it++) {
 
         // transition matrix for current rec fracs
@@ -263,7 +265,7 @@ NumericVector est_map2_grouped(const String crosstype,
         }
 
         // check convergence
-        bool converged = true;
+        converged = true;
         for(int pos=0; pos<n_rf; pos++) {
             if(fabs(prev_rec_frac[pos] - cur_rec_frac[pos]) > tol*(cur_rec_frac[pos]+tol*100.0)) {
                 converged = false;
@@ -276,6 +278,8 @@ NumericVector est_map2_grouped(const String crosstype,
         prev_rec_frac = clone(cur_rec_frac);
     } // end loop over iterations
 
+    if(!converged)
+        r_warning("est_map reaching maximum iterations without converging");
 
     // transition matrix for current rec fracs
     std::vector<std::vector<NumericMatrix> > step_matrix(n_cross_group);
@@ -387,6 +391,7 @@ NumericVector est_map2_founderorder(const String crosstype,
     for(int ind=0; ind<n_ind; ind++)
         founder_index(_,ind) = invert_founder_index(cross_info(_,ind));
 
+    bool converged = false; // flag for convergence
     for(int it=0; it<max_iterations; it++) {
 
         // transition matrix for current rec fracs
@@ -471,7 +476,7 @@ NumericVector est_map2_founderorder(const String crosstype,
         }
 
         // check convergence
-        bool converged = true;
+        converged = true;
         for(int pos=0; pos<n_rf; pos++) {
             if(fabs(prev_rec_frac[pos] - cur_rec_frac[pos]) > tol*(cur_rec_frac[pos]+tol*100.0)) {
                 converged = false;
@@ -484,6 +489,9 @@ NumericVector est_map2_founderorder(const String crosstype,
         prev_rec_frac = clone(cur_rec_frac);
     } // end loop over iterations
 
+
+    if(!converged)
+        r_warning("est_map reaching maximum iterations without converging");
 
     // transition matrix for current rec fracs
     std::vector<NumericMatrix> step_matrix = cross->calc_stepmatrix(cur_rec_frac, is_X_chr,

--- a/tests/testthat/test-simgeno.R
+++ b/tests/testthat/test-simgeno.R
@@ -4,9 +4,11 @@ context("sim_geno")
 
 test_that("sim_geno riself", {
 
+    grav2 <- read_cross2(system.file("extdata", "grav2.zip", package="qtl2geno"))
+
     RNGkind("Mersenne-Twister")
     set.seed(20150918)
-    grav2 <- read_cross2(system.file("extdata", "grav2.zip", package="qtl2geno"))
+
     map <- insert_pseudomarkers(grav2$gmap, step=1)
     dr <- sim_geno(grav2, map, n_draws=2, err=0.002)
 
@@ -60,9 +62,10 @@ test_that("sim_geno riself", {
 
 test_that("sim_geno f2", {
 
+    iron <- read_cross2(system.file("extdata", "iron.zip", package="qtl2geno"))
+
     RNGkind("Mersenne-Twister")
     set.seed(20150918)
-    iron <- read_cross2(system.file("extdata", "iron.zip", package="qtl2geno"))
     map <- insert_pseudomarkers(iron$gmap, step=1)
     dr <- sim_geno(iron, map, n_draws=2, err=0.002)
 


### PR DESCRIPTION
- Fix bugs in `read_cross2` (fixes Issue #130):

   - extract zip files to separate directory
   - give error if zip file contains multiple YAML or JSON files
   - give warning if zip file contains both a YAML file and a JSON file (and use YAML file)
   - Ignore `__MACOSX/._` files

- `est_map` now gives a warning if it doesn't converge (fixes Issue #128).