### PR TITLE
Add cross types "dh6" and "ail3"

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,5 +1,5 @@
 Package: qtl2geno
-Version: 0.5-25
+Version: 0.5-26
 Date: 2017-06-29
 Title: Treatment of Marker Genotypes for QTL Experiments
 Description: Functions to calculate QTL genotype probabilities, impute

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: qtl2geno
 Version: 0.5-26
-Date: 2017-06-29
+Date: 2017-06-30
 Title: Treatment of Marker Genotypes for QTL Experiments
 Description: Functions to calculate QTL genotype probabilities, impute
     QTL genotypes, and estimate genetic maps. Part of R/qtl2, a

--- a/NEWS.md
+++ b/NEWS.md
@@ -6,6 +6,12 @@
   a set of maize MAGIC populations developed at the
   [Wisconsin Crop Innovation Center](https://cropinnovation.cals.wisc.edu/).
 
+### Minor changes
+
+- Added internal C++ function `check_founder_geno_size()` for checking
+  the dimensions of the founder genotype data from R, and added this
+  check to the `check_cross2()` function.
+
 
 ## qtl2geno 0.5-25 (2017-06-29)
 

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,3 +1,12 @@
+## qtl2geno 0.5-26 (2017-06-29)
+
+### New features
+
+- Implemented a new crosstype, `"dh6"` for 6-way doubled haploids, for
+  a set of maize MAGIC populations developed at the
+  [Wisconsin Crop Innovation Center](https://cropinnovation.cals.wisc.edu/).
+
+
 ## qtl2geno 0.5-25 (2017-06-29)
 
 ### New features

--- a/NEWS.md
+++ b/NEWS.md
@@ -2,9 +2,10 @@
 
 ### New features
 
-- Implemented a new crosstype, `"dh6"` for 6-way doubled haploids, for
+- Implemented two new crosstypes: `"dh6"` for 6-way doubled haploids (for
   a set of maize MAGIC populations developed at the
-  [Wisconsin Crop Innovation Center](https://cropinnovation.cals.wisc.edu/).
+  [Wisconsin Crop Innovation Center](https://cropinnovation.cals.wisc.edu/))
+  and `ail3` for 3-way advanced intercross lines.
 
 ### Minor changes
 

--- a/R/RcppExports.R
+++ b/R/RcppExports.R
@@ -2,190 +2,190 @@
 # Generator token: 10BE3573-1514-4C36-9D1C-5A225CD40393
 
 .calc_kinship <- function(prob_array) {
-    .Call(qtl2geno_calc_kinship, prob_array)
+    .Call('qtl2geno_calc_kinship', PACKAGE = 'qtl2geno', prob_array)
 }
 
 .crosstype_supported <- function(crosstype) {
-    .Call(qtl2geno_crosstype_supported, crosstype)
+    .Call('qtl2geno_crosstype_supported', PACKAGE = 'qtl2geno', crosstype)
 }
 
 .count_invalid_genotypes <- function(crosstype, genotypes, is_X_chr, is_female, cross_info) {
-    .Call(qtl2geno_count_invalid_genotypes, crosstype, genotypes, is_X_chr, is_female, cross_info)
+    .Call('qtl2geno_count_invalid_genotypes', PACKAGE = 'qtl2geno', crosstype, genotypes, is_X_chr, is_female, cross_info)
 }
 
 check_crossinfo <- function(crosstype, cross_info, any_x_chr) {
-    .Call(qtl2geno_check_crossinfo, crosstype, cross_info, any_x_chr)
+    .Call('qtl2geno_check_crossinfo', PACKAGE = 'qtl2geno', crosstype, cross_info, any_x_chr)
 }
 
 check_is_female_vector <- function(crosstype, is_female, any_x_chr) {
-    .Call(qtl2geno_check_is_female_vector, crosstype, is_female, any_x_chr)
+    .Call('qtl2geno_check_is_female_vector', PACKAGE = 'qtl2geno', crosstype, is_female, any_x_chr)
 }
 
 check_handle_x_chr <- function(crosstype, any_x_chr) {
-    .Call(qtl2geno_check_handle_x_chr, crosstype, any_x_chr)
+    .Call('qtl2geno_check_handle_x_chr', PACKAGE = 'qtl2geno', crosstype, any_x_chr)
 }
 
 .chisq_colpairs <- function(input) {
-    .Call(qtl2geno_chisq_colpairs, input)
+    .Call('qtl2geno_chisq_colpairs', PACKAGE = 'qtl2geno', input)
 }
 
 .compare_geno <- function(geno) {
-    .Call(qtl2geno_compare_geno, geno)
+    .Call('qtl2geno_compare_geno', PACKAGE = 'qtl2geno', geno)
 }
 
 .count_xo <- function(geno, crosstype, is_X_chr) {
-    .Call(qtl2geno_count_xo, geno, crosstype, is_X_chr)
+    .Call('qtl2geno_count_xo', PACKAGE = 'qtl2geno', geno, crosstype, is_X_chr)
 }
 
 .count_xo_3d <- function(geno_array, crosstype, is_X_chr) {
-    .Call(qtl2geno_count_xo_3d, geno_array, crosstype, is_X_chr)
+    .Call('qtl2geno_count_xo_3d', PACKAGE = 'qtl2geno', geno_array, crosstype, is_X_chr)
 }
 
 mpp_encode_alleles <- function(allele1, allele2, n_alleles, phase_known) {
-    .Call(qtl2geno_mpp_encode_alleles, allele1, allele2, n_alleles, phase_known)
+    .Call('qtl2geno_mpp_encode_alleles', PACKAGE = 'qtl2geno', allele1, allele2, n_alleles, phase_known)
 }
 
 mpp_decode_geno <- function(true_gen, n_alleles, phase_known) {
-    .Call(qtl2geno_mpp_decode_geno, true_gen, n_alleles, phase_known)
+    .Call('qtl2geno_mpp_decode_geno', PACKAGE = 'qtl2geno', true_gen, n_alleles, phase_known)
 }
 
 mpp_is_het <- function(true_gen, n_alleles, phase_known) {
-    .Call(qtl2geno_mpp_is_het, true_gen, n_alleles, phase_known)
+    .Call('qtl2geno_mpp_is_het', PACKAGE = 'qtl2geno', true_gen, n_alleles, phase_known)
 }
 
 mpp_geno_names <- function(alleles, is_x_chr) {
-    .Call(qtl2geno_mpp_geno_names, alleles, is_x_chr)
+    .Call('qtl2geno_mpp_geno_names', PACKAGE = 'qtl2geno', alleles, is_x_chr)
 }
 
 invert_founder_index <- function(cross_info) {
-    .Call(qtl2geno_invert_founder_index, cross_info)
+    .Call('qtl2geno_invert_founder_index', PACKAGE = 'qtl2geno', cross_info)
 }
 
 .find_ibd_segments <- function(g1, g2, p, error_prob) {
-    .Call(qtl2geno_find_ibd_segments, g1, g2, p, error_prob)
+    .Call('qtl2geno_find_ibd_segments', PACKAGE = 'qtl2geno', g1, g2, p, error_prob)
 }
 
 geno_names <- function(crosstype, alleles, is_x_chr) {
-    .Call(qtl2geno_geno_names, crosstype, alleles, is_x_chr)
+    .Call('qtl2geno_geno_names', PACKAGE = 'qtl2geno', crosstype, alleles, is_x_chr)
 }
 
 nalleles <- function(crosstype) {
-    .Call(qtl2geno_nalleles, crosstype)
+    .Call('qtl2geno_nalleles', PACKAGE = 'qtl2geno', crosstype)
 }
 
 .genoprob_to_alleleprob <- function(crosstype, prob_array, is_x_chr) {
-    .Call(qtl2geno_genoprob_to_alleleprob, crosstype, prob_array, is_x_chr)
+    .Call('qtl2geno_genoprob_to_alleleprob', PACKAGE = 'qtl2geno', crosstype, prob_array, is_x_chr)
 }
 
 .get_x_covar <- function(crosstype, is_female, cross_info) {
-    .Call(qtl2geno_get_x_covar, crosstype, is_female, cross_info)
+    .Call('qtl2geno_get_x_covar', PACKAGE = 'qtl2geno', crosstype, is_female, cross_info)
 }
 
 .calc_errorlod <- function(crosstype, probs, genotypes, founder_geno, is_X_chr, is_female, cross_info) {
-    .Call(qtl2geno_calc_errorlod, crosstype, probs, genotypes, founder_geno, is_X_chr, is_female, cross_info)
+    .Call('qtl2geno_calc_errorlod', PACKAGE = 'qtl2geno', crosstype, probs, genotypes, founder_geno, is_X_chr, is_female, cross_info)
 }
 
 .calc_genoprob <- function(crosstype, genotypes, founder_geno, is_X_chr, is_female, cross_info, rec_frac, marker_index, error_prob) {
-    .Call(qtl2geno_calc_genoprob, crosstype, genotypes, founder_geno, is_X_chr, is_female, cross_info, rec_frac, marker_index, error_prob)
+    .Call('qtl2geno_calc_genoprob', PACKAGE = 'qtl2geno', crosstype, genotypes, founder_geno, is_X_chr, is_female, cross_info, rec_frac, marker_index, error_prob)
 }
 
 .calc_genoprob2 <- function(crosstype, genotypes, founder_geno, is_X_chr, is_female, cross_info, rec_frac, marker_index, error_prob) {
-    .Call(qtl2geno_calc_genoprob2, crosstype, genotypes, founder_geno, is_X_chr, is_female, cross_info, rec_frac, marker_index, error_prob)
+    .Call('qtl2geno_calc_genoprob2', PACKAGE = 'qtl2geno', crosstype, genotypes, founder_geno, is_X_chr, is_female, cross_info, rec_frac, marker_index, error_prob)
 }
 
 .est_map <- function(crosstype, genotypes, founder_geno, is_X_chr, is_female, cross_info, rec_frac, error_prob, max_iterations, tol, verbose) {
-    .Call(qtl2geno_est_map, crosstype, genotypes, founder_geno, is_X_chr, is_female, cross_info, rec_frac, error_prob, max_iterations, tol, verbose)
+    .Call('qtl2geno_est_map', PACKAGE = 'qtl2geno', crosstype, genotypes, founder_geno, is_X_chr, is_female, cross_info, rec_frac, error_prob, max_iterations, tol, verbose)
 }
 
 .est_map2 <- function(crosstype, genotypes, founder_geno, is_X_chr, is_female, cross_info, cross_group, unique_cross_group, rec_frac, error_prob, max_iterations, tol, verbose) {
-    .Call(qtl2geno_est_map2, crosstype, genotypes, founder_geno, is_X_chr, is_female, cross_info, cross_group, unique_cross_group, rec_frac, error_prob, max_iterations, tol, verbose)
+    .Call('qtl2geno_est_map2', PACKAGE = 'qtl2geno', crosstype, genotypes, founder_geno, is_X_chr, is_female, cross_info, cross_group, unique_cross_group, rec_frac, error_prob, max_iterations, tol, verbose)
 }
 
 .sim_geno <- function(crosstype, genotypes, founder_geno, is_X_chr, is_female, cross_info, rec_frac, marker_index, error_prob, n_draws) {
-    .Call(qtl2geno_sim_geno, crosstype, genotypes, founder_geno, is_X_chr, is_female, cross_info, rec_frac, marker_index, error_prob, n_draws)
+    .Call('qtl2geno_sim_geno', PACKAGE = 'qtl2geno', crosstype, genotypes, founder_geno, is_X_chr, is_female, cross_info, rec_frac, marker_index, error_prob, n_draws)
 }
 
 .sim_geno2 <- function(crosstype, genotypes, founder_geno, is_X_chr, is_female, cross_info, rec_frac, marker_index, error_prob, n_draws) {
-    .Call(qtl2geno_sim_geno2, crosstype, genotypes, founder_geno, is_X_chr, is_female, cross_info, rec_frac, marker_index, error_prob, n_draws)
+    .Call('qtl2geno_sim_geno2', PACKAGE = 'qtl2geno', crosstype, genotypes, founder_geno, is_X_chr, is_female, cross_info, rec_frac, marker_index, error_prob, n_draws)
 }
 
 addlog <- function(a, b) {
-    .Call(qtl2geno_addlog, a, b)
+    .Call('qtl2geno_addlog', PACKAGE = 'qtl2geno', a, b)
 }
 
 subtrlog <- function(a, b) {
-    .Call(qtl2geno_subtrlog, a, b)
+    .Call('qtl2geno_subtrlog', PACKAGE = 'qtl2geno', a, b)
 }
 
 .viterbi <- function(crosstype, genotypes, founder_geno, is_X_chr, is_female, cross_info, rec_frac, marker_index, error_prob) {
-    .Call(qtl2geno_viterbi, crosstype, genotypes, founder_geno, is_X_chr, is_female, cross_info, rec_frac, marker_index, error_prob)
+    .Call('qtl2geno_viterbi', PACKAGE = 'qtl2geno', crosstype, genotypes, founder_geno, is_X_chr, is_female, cross_info, rec_frac, marker_index, error_prob)
 }
 
 .viterbi2 <- function(crosstype, genotypes, founder_geno, is_X_chr, is_female, cross_info, rec_frac, marker_index, error_prob) {
-    .Call(qtl2geno_viterbi2, crosstype, genotypes, founder_geno, is_X_chr, is_female, cross_info, rec_frac, marker_index, error_prob)
+    .Call('qtl2geno_viterbi2', PACKAGE = 'qtl2geno', crosstype, genotypes, founder_geno, is_X_chr, is_female, cross_info, rec_frac, marker_index, error_prob)
 }
 
 .locate_xo <- function(geno, map, crosstype, is_X_chr) {
-    .Call(qtl2geno_locate_xo, geno, map, crosstype, is_X_chr)
+    .Call('qtl2geno_locate_xo', PACKAGE = 'qtl2geno', geno, map, crosstype, is_X_chr)
 }
 
 .maxmarg <- function(prob_array, minprob, tol) {
-    .Call(qtl2geno_maxmarg, prob_array, minprob, tol)
+    .Call('qtl2geno_maxmarg', PACKAGE = 'qtl2geno', prob_array, minprob, tol)
 }
 
 .reduce_markers <- function(pos, weights, min_dist) {
-    .Call(qtl2geno_reduce_markers, pos, weights, min_dist)
+    .Call('qtl2geno_reduce_markers', PACKAGE = 'qtl2geno', pos, weights, min_dist)
 }
 
 test_init <- function(crosstype, true_gen, is_x_chr, is_female, cross_info) {
-    .Call(qtl2geno_test_init, crosstype, true_gen, is_x_chr, is_female, cross_info)
+    .Call('qtl2geno_test_init', PACKAGE = 'qtl2geno', crosstype, true_gen, is_x_chr, is_female, cross_info)
 }
 
 test_emit <- function(crosstype, obs_gen, true_gen, error_prob, founder_geno, is_x_chr, is_female, cross_info) {
-    .Call(qtl2geno_test_emit, crosstype, obs_gen, true_gen, error_prob, founder_geno, is_x_chr, is_female, cross_info)
+    .Call('qtl2geno_test_emit', PACKAGE = 'qtl2geno', crosstype, obs_gen, true_gen, error_prob, founder_geno, is_x_chr, is_female, cross_info)
 }
 
 test_step <- function(crosstype, gen_left, gen_right, rec_frac, is_x_chr, is_female, cross_info) {
-    .Call(qtl2geno_test_step, crosstype, gen_left, gen_right, rec_frac, is_x_chr, is_female, cross_info)
+    .Call('qtl2geno_test_step', PACKAGE = 'qtl2geno', crosstype, gen_left, gen_right, rec_frac, is_x_chr, is_female, cross_info)
 }
 
 test_check_geno <- function(crosstype, gen, is_observed_value, is_x_chr, is_female, cross_info) {
-    .Call(qtl2geno_test_check_geno, crosstype, gen, is_observed_value, is_x_chr, is_female, cross_info)
+    .Call('qtl2geno_test_check_geno', PACKAGE = 'qtl2geno', crosstype, gen, is_observed_value, is_x_chr, is_female, cross_info)
 }
 
 test_possible_gen <- function(crosstype, is_x_chr, is_female, cross_info) {
-    .Call(qtl2geno_test_possible_gen, crosstype, is_x_chr, is_female, cross_info)
+    .Call('qtl2geno_test_possible_gen', PACKAGE = 'qtl2geno', crosstype, is_x_chr, is_female, cross_info)
 }
 
 test_ngen <- function(crosstype, is_x_chr) {
-    .Call(qtl2geno_test_ngen, crosstype, is_x_chr)
+    .Call('qtl2geno_test_ngen', PACKAGE = 'qtl2geno', crosstype, is_x_chr)
 }
 
 test_nrec <- function(crosstype, gen_left, gen_right, is_x_chr, is_female, cross_info) {
-    .Call(qtl2geno_test_nrec, crosstype, gen_left, gen_right, is_x_chr, is_female, cross_info)
+    .Call('qtl2geno_test_nrec', PACKAGE = 'qtl2geno', crosstype, gen_left, gen_right, is_x_chr, is_female, cross_info)
 }
 
 test_founder_geno_values <- function(crosstype, founder_geno) {
-    .Call(qtl2geno_test_founder_geno_values, crosstype, founder_geno)
+    .Call('qtl2geno_test_founder_geno_values', PACKAGE = 'qtl2geno', crosstype, founder_geno)
 }
 
 need_founder_geno <- function(crosstype) {
-    .Call(qtl2geno_need_founder_geno, crosstype)
+    .Call('qtl2geno_need_founder_geno', PACKAGE = 'qtl2geno', crosstype)
 }
 
 check_founder_geno_size <- function(crosstype, founder_geno, n_markers) {
-    .Call(qtl2geno_check_founder_geno_size, crosstype, founder_geno, n_markers)
+    .Call('qtl2geno_check_founder_geno_size', PACKAGE = 'qtl2geno', crosstype, founder_geno, n_markers)
 }
 
 test_emitmatrix <- function(crosstype, error_prob, max_obsgeno, founder_geno, is_x_chr, is_female, cross_info) {
-    .Call(qtl2geno_test_emitmatrix, crosstype, error_prob, max_obsgeno, founder_geno, is_x_chr, is_female, cross_info)
+    .Call('qtl2geno_test_emitmatrix', PACKAGE = 'qtl2geno', crosstype, error_prob, max_obsgeno, founder_geno, is_x_chr, is_female, cross_info)
 }
 
 test_stepmatrix <- function(crosstype, rec_frac, is_x_chr, is_female, cross_info) {
-    .Call(qtl2geno_test_stepmatrix, crosstype, rec_frac, is_x_chr, is_female, cross_info)
+    .Call('qtl2geno_test_stepmatrix', PACKAGE = 'qtl2geno', crosstype, rec_frac, is_x_chr, is_female, cross_info)
 }
 
 test_initvector <- function(crosstype, is_x_chr, is_female, cross_info) {
-    .Call(qtl2geno_test_initvector, crosstype, is_x_chr, is_female, cross_info)
+    .Call('qtl2geno_test_initvector', PACKAGE = 'qtl2geno', crosstype, is_x_chr, is_female, cross_info)
 }
 

--- a/R/RcppExports.R
+++ b/R/RcppExports.R
@@ -2,186 +2,190 @@
 # Generator token: 10BE3573-1514-4C36-9D1C-5A225CD40393
 
 .calc_kinship <- function(prob_array) {
-    .Call('qtl2geno_calc_kinship', PACKAGE = 'qtl2geno', prob_array)
+    .Call(qtl2geno_calc_kinship, prob_array)
 }
 
 .crosstype_supported <- function(crosstype) {
-    .Call('qtl2geno_crosstype_supported', PACKAGE = 'qtl2geno', crosstype)
+    .Call(qtl2geno_crosstype_supported, crosstype)
 }
 
 .count_invalid_genotypes <- function(crosstype, genotypes, is_X_chr, is_female, cross_info) {
-    .Call('qtl2geno_count_invalid_genotypes', PACKAGE = 'qtl2geno', crosstype, genotypes, is_X_chr, is_female, cross_info)
+    .Call(qtl2geno_count_invalid_genotypes, crosstype, genotypes, is_X_chr, is_female, cross_info)
 }
 
 check_crossinfo <- function(crosstype, cross_info, any_x_chr) {
-    .Call('qtl2geno_check_crossinfo', PACKAGE = 'qtl2geno', crosstype, cross_info, any_x_chr)
+    .Call(qtl2geno_check_crossinfo, crosstype, cross_info, any_x_chr)
 }
 
 check_is_female_vector <- function(crosstype, is_female, any_x_chr) {
-    .Call('qtl2geno_check_is_female_vector', PACKAGE = 'qtl2geno', crosstype, is_female, any_x_chr)
+    .Call(qtl2geno_check_is_female_vector, crosstype, is_female, any_x_chr)
 }
 
 check_handle_x_chr <- function(crosstype, any_x_chr) {
-    .Call('qtl2geno_check_handle_x_chr', PACKAGE = 'qtl2geno', crosstype, any_x_chr)
+    .Call(qtl2geno_check_handle_x_chr, crosstype, any_x_chr)
 }
 
 .chisq_colpairs <- function(input) {
-    .Call('qtl2geno_chisq_colpairs', PACKAGE = 'qtl2geno', input)
+    .Call(qtl2geno_chisq_colpairs, input)
 }
 
 .compare_geno <- function(geno) {
-    .Call('qtl2geno_compare_geno', PACKAGE = 'qtl2geno', geno)
+    .Call(qtl2geno_compare_geno, geno)
 }
 
 .count_xo <- function(geno, crosstype, is_X_chr) {
-    .Call('qtl2geno_count_xo', PACKAGE = 'qtl2geno', geno, crosstype, is_X_chr)
+    .Call(qtl2geno_count_xo, geno, crosstype, is_X_chr)
 }
 
 .count_xo_3d <- function(geno_array, crosstype, is_X_chr) {
-    .Call('qtl2geno_count_xo_3d', PACKAGE = 'qtl2geno', geno_array, crosstype, is_X_chr)
+    .Call(qtl2geno_count_xo_3d, geno_array, crosstype, is_X_chr)
 }
 
 mpp_encode_alleles <- function(allele1, allele2, n_alleles, phase_known) {
-    .Call('qtl2geno_mpp_encode_alleles', PACKAGE = 'qtl2geno', allele1, allele2, n_alleles, phase_known)
+    .Call(qtl2geno_mpp_encode_alleles, allele1, allele2, n_alleles, phase_known)
 }
 
 mpp_decode_geno <- function(true_gen, n_alleles, phase_known) {
-    .Call('qtl2geno_mpp_decode_geno', PACKAGE = 'qtl2geno', true_gen, n_alleles, phase_known)
+    .Call(qtl2geno_mpp_decode_geno, true_gen, n_alleles, phase_known)
 }
 
 mpp_is_het <- function(true_gen, n_alleles, phase_known) {
-    .Call('qtl2geno_mpp_is_het', PACKAGE = 'qtl2geno', true_gen, n_alleles, phase_known)
+    .Call(qtl2geno_mpp_is_het, true_gen, n_alleles, phase_known)
 }
 
 mpp_geno_names <- function(alleles, is_x_chr) {
-    .Call('qtl2geno_mpp_geno_names', PACKAGE = 'qtl2geno', alleles, is_x_chr)
+    .Call(qtl2geno_mpp_geno_names, alleles, is_x_chr)
 }
 
 invert_founder_index <- function(cross_info) {
-    .Call('qtl2geno_invert_founder_index', PACKAGE = 'qtl2geno', cross_info)
+    .Call(qtl2geno_invert_founder_index, cross_info)
 }
 
 .find_ibd_segments <- function(g1, g2, p, error_prob) {
-    .Call('qtl2geno_find_ibd_segments', PACKAGE = 'qtl2geno', g1, g2, p, error_prob)
+    .Call(qtl2geno_find_ibd_segments, g1, g2, p, error_prob)
 }
 
 geno_names <- function(crosstype, alleles, is_x_chr) {
-    .Call('qtl2geno_geno_names', PACKAGE = 'qtl2geno', crosstype, alleles, is_x_chr)
+    .Call(qtl2geno_geno_names, crosstype, alleles, is_x_chr)
 }
 
 nalleles <- function(crosstype) {
-    .Call('qtl2geno_nalleles', PACKAGE = 'qtl2geno', crosstype)
+    .Call(qtl2geno_nalleles, crosstype)
 }
 
 .genoprob_to_alleleprob <- function(crosstype, prob_array, is_x_chr) {
-    .Call('qtl2geno_genoprob_to_alleleprob', PACKAGE = 'qtl2geno', crosstype, prob_array, is_x_chr)
+    .Call(qtl2geno_genoprob_to_alleleprob, crosstype, prob_array, is_x_chr)
 }
 
 .get_x_covar <- function(crosstype, is_female, cross_info) {
-    .Call('qtl2geno_get_x_covar', PACKAGE = 'qtl2geno', crosstype, is_female, cross_info)
+    .Call(qtl2geno_get_x_covar, crosstype, is_female, cross_info)
 }
 
 .calc_errorlod <- function(crosstype, probs, genotypes, founder_geno, is_X_chr, is_female, cross_info) {
-    .Call('qtl2geno_calc_errorlod', PACKAGE = 'qtl2geno', crosstype, probs, genotypes, founder_geno, is_X_chr, is_female, cross_info)
+    .Call(qtl2geno_calc_errorlod, crosstype, probs, genotypes, founder_geno, is_X_chr, is_female, cross_info)
 }
 
 .calc_genoprob <- function(crosstype, genotypes, founder_geno, is_X_chr, is_female, cross_info, rec_frac, marker_index, error_prob) {
-    .Call('qtl2geno_calc_genoprob', PACKAGE = 'qtl2geno', crosstype, genotypes, founder_geno, is_X_chr, is_female, cross_info, rec_frac, marker_index, error_prob)
+    .Call(qtl2geno_calc_genoprob, crosstype, genotypes, founder_geno, is_X_chr, is_female, cross_info, rec_frac, marker_index, error_prob)
 }
 
 .calc_genoprob2 <- function(crosstype, genotypes, founder_geno, is_X_chr, is_female, cross_info, rec_frac, marker_index, error_prob) {
-    .Call('qtl2geno_calc_genoprob2', PACKAGE = 'qtl2geno', crosstype, genotypes, founder_geno, is_X_chr, is_female, cross_info, rec_frac, marker_index, error_prob)
+    .Call(qtl2geno_calc_genoprob2, crosstype, genotypes, founder_geno, is_X_chr, is_female, cross_info, rec_frac, marker_index, error_prob)
 }
 
 .est_map <- function(crosstype, genotypes, founder_geno, is_X_chr, is_female, cross_info, rec_frac, error_prob, max_iterations, tol, verbose) {
-    .Call('qtl2geno_est_map', PACKAGE = 'qtl2geno', crosstype, genotypes, founder_geno, is_X_chr, is_female, cross_info, rec_frac, error_prob, max_iterations, tol, verbose)
+    .Call(qtl2geno_est_map, crosstype, genotypes, founder_geno, is_X_chr, is_female, cross_info, rec_frac, error_prob, max_iterations, tol, verbose)
 }
 
 .est_map2 <- function(crosstype, genotypes, founder_geno, is_X_chr, is_female, cross_info, cross_group, unique_cross_group, rec_frac, error_prob, max_iterations, tol, verbose) {
-    .Call('qtl2geno_est_map2', PACKAGE = 'qtl2geno', crosstype, genotypes, founder_geno, is_X_chr, is_female, cross_info, cross_group, unique_cross_group, rec_frac, error_prob, max_iterations, tol, verbose)
+    .Call(qtl2geno_est_map2, crosstype, genotypes, founder_geno, is_X_chr, is_female, cross_info, cross_group, unique_cross_group, rec_frac, error_prob, max_iterations, tol, verbose)
 }
 
 .sim_geno <- function(crosstype, genotypes, founder_geno, is_X_chr, is_female, cross_info, rec_frac, marker_index, error_prob, n_draws) {
-    .Call('qtl2geno_sim_geno', PACKAGE = 'qtl2geno', crosstype, genotypes, founder_geno, is_X_chr, is_female, cross_info, rec_frac, marker_index, error_prob, n_draws)
+    .Call(qtl2geno_sim_geno, crosstype, genotypes, founder_geno, is_X_chr, is_female, cross_info, rec_frac, marker_index, error_prob, n_draws)
 }
 
 .sim_geno2 <- function(crosstype, genotypes, founder_geno, is_X_chr, is_female, cross_info, rec_frac, marker_index, error_prob, n_draws) {
-    .Call('qtl2geno_sim_geno2', PACKAGE = 'qtl2geno', crosstype, genotypes, founder_geno, is_X_chr, is_female, cross_info, rec_frac, marker_index, error_prob, n_draws)
+    .Call(qtl2geno_sim_geno2, crosstype, genotypes, founder_geno, is_X_chr, is_female, cross_info, rec_frac, marker_index, error_prob, n_draws)
 }
 
 addlog <- function(a, b) {
-    .Call('qtl2geno_addlog', PACKAGE = 'qtl2geno', a, b)
+    .Call(qtl2geno_addlog, a, b)
 }
 
 subtrlog <- function(a, b) {
-    .Call('qtl2geno_subtrlog', PACKAGE = 'qtl2geno', a, b)
+    .Call(qtl2geno_subtrlog, a, b)
 }
 
 .viterbi <- function(crosstype, genotypes, founder_geno, is_X_chr, is_female, cross_info, rec_frac, marker_index, error_prob) {
-    .Call('qtl2geno_viterbi', PACKAGE = 'qtl2geno', crosstype, genotypes, founder_geno, is_X_chr, is_female, cross_info, rec_frac, marker_index, error_prob)
+    .Call(qtl2geno_viterbi, crosstype, genotypes, founder_geno, is_X_chr, is_female, cross_info, rec_frac, marker_index, error_prob)
 }
 
 .viterbi2 <- function(crosstype, genotypes, founder_geno, is_X_chr, is_female, cross_info, rec_frac, marker_index, error_prob) {
-    .Call('qtl2geno_viterbi2', PACKAGE = 'qtl2geno', crosstype, genotypes, founder_geno, is_X_chr, is_female, cross_info, rec_frac, marker_index, error_prob)
+    .Call(qtl2geno_viterbi2, crosstype, genotypes, founder_geno, is_X_chr, is_female, cross_info, rec_frac, marker_index, error_prob)
 }
 
 .locate_xo <- function(geno, map, crosstype, is_X_chr) {
-    .Call('qtl2geno_locate_xo', PACKAGE = 'qtl2geno', geno, map, crosstype, is_X_chr)
+    .Call(qtl2geno_locate_xo, geno, map, crosstype, is_X_chr)
 }
 
 .maxmarg <- function(prob_array, minprob, tol) {
-    .Call('qtl2geno_maxmarg', PACKAGE = 'qtl2geno', prob_array, minprob, tol)
+    .Call(qtl2geno_maxmarg, prob_array, minprob, tol)
 }
 
 .reduce_markers <- function(pos, weights, min_dist) {
-    .Call('qtl2geno_reduce_markers', PACKAGE = 'qtl2geno', pos, weights, min_dist)
+    .Call(qtl2geno_reduce_markers, pos, weights, min_dist)
 }
 
 test_init <- function(crosstype, true_gen, is_x_chr, is_female, cross_info) {
-    .Call('qtl2geno_test_init', PACKAGE = 'qtl2geno', crosstype, true_gen, is_x_chr, is_female, cross_info)
+    .Call(qtl2geno_test_init, crosstype, true_gen, is_x_chr, is_female, cross_info)
 }
 
 test_emit <- function(crosstype, obs_gen, true_gen, error_prob, founder_geno, is_x_chr, is_female, cross_info) {
-    .Call('qtl2geno_test_emit', PACKAGE = 'qtl2geno', crosstype, obs_gen, true_gen, error_prob, founder_geno, is_x_chr, is_female, cross_info)
+    .Call(qtl2geno_test_emit, crosstype, obs_gen, true_gen, error_prob, founder_geno, is_x_chr, is_female, cross_info)
 }
 
 test_step <- function(crosstype, gen_left, gen_right, rec_frac, is_x_chr, is_female, cross_info) {
-    .Call('qtl2geno_test_step', PACKAGE = 'qtl2geno', crosstype, gen_left, gen_right, rec_frac, is_x_chr, is_female, cross_info)
+    .Call(qtl2geno_test_step, crosstype, gen_left, gen_right, rec_frac, is_x_chr, is_female, cross_info)
 }
 
 test_check_geno <- function(crosstype, gen, is_observed_value, is_x_chr, is_female, cross_info) {
-    .Call('qtl2geno_test_check_geno', PACKAGE = 'qtl2geno', crosstype, gen, is_observed_value, is_x_chr, is_female, cross_info)
+    .Call(qtl2geno_test_check_geno, crosstype, gen, is_observed_value, is_x_chr, is_female, cross_info)
 }
 
 test_possible_gen <- function(crosstype, is_x_chr, is_female, cross_info) {
-    .Call('qtl2geno_test_possible_gen', PACKAGE = 'qtl2geno', crosstype, is_x_chr, is_female, cross_info)
+    .Call(qtl2geno_test_possible_gen, crosstype, is_x_chr, is_female, cross_info)
 }
 
 test_ngen <- function(crosstype, is_x_chr) {
-    .Call('qtl2geno_test_ngen', PACKAGE = 'qtl2geno', crosstype, is_x_chr)
+    .Call(qtl2geno_test_ngen, crosstype, is_x_chr)
 }
 
 test_nrec <- function(crosstype, gen_left, gen_right, is_x_chr, is_female, cross_info) {
-    .Call('qtl2geno_test_nrec', PACKAGE = 'qtl2geno', crosstype, gen_left, gen_right, is_x_chr, is_female, cross_info)
+    .Call(qtl2geno_test_nrec, crosstype, gen_left, gen_right, is_x_chr, is_female, cross_info)
 }
 
 test_founder_geno_values <- function(crosstype, founder_geno) {
-    .Call('qtl2geno_test_founder_geno_values', PACKAGE = 'qtl2geno', crosstype, founder_geno)
+    .Call(qtl2geno_test_founder_geno_values, crosstype, founder_geno)
 }
 
 need_founder_geno <- function(crosstype) {
-    .Call('qtl2geno_need_founder_geno', PACKAGE = 'qtl2geno', crosstype)
+    .Call(qtl2geno_need_founder_geno, crosstype)
+}
+
+check_founder_geno_size <- function(crosstype, founder_geno, n_markers) {
+    .Call(qtl2geno_check_founder_geno_size, crosstype, founder_geno, n_markers)
 }
 
 test_emitmatrix <- function(crosstype, error_prob, max_obsgeno, founder_geno, is_x_chr, is_female, cross_info) {
-    .Call('qtl2geno_test_emitmatrix', PACKAGE = 'qtl2geno', crosstype, error_prob, max_obsgeno, founder_geno, is_x_chr, is_female, cross_info)
+    .Call(qtl2geno_test_emitmatrix, crosstype, error_prob, max_obsgeno, founder_geno, is_x_chr, is_female, cross_info)
 }
 
 test_stepmatrix <- function(crosstype, rec_frac, is_x_chr, is_female, cross_info) {
-    .Call('qtl2geno_test_stepmatrix', PACKAGE = 'qtl2geno', crosstype, rec_frac, is_x_chr, is_female, cross_info)
+    .Call(qtl2geno_test_stepmatrix, crosstype, rec_frac, is_x_chr, is_female, cross_info)
 }
 
 test_initvector <- function(crosstype, is_x_chr, is_female, cross_info) {
-    .Call('qtl2geno_test_initvector', PACKAGE = 'qtl2geno', crosstype, is_x_chr, is_female, cross_info)
+    .Call(qtl2geno_test_initvector, crosstype, is_x_chr, is_female, cross_info)
 }
 

--- a/R/check_cross2.R
+++ b/R/check_cross2.R
@@ -339,9 +339,8 @@ function(cross2)
                     warning("names(geno) != names(founder_geno)")
                 }
                 for(i in seq(along=geno)) {
-                    if(ncol(geno[[i]]) != ncol(founder_geno[[i]])) {
+                    if(!check_founder_geno_size(crosstype, founder_geno[[i]], ncol(geno[[i]]))) {
                         result <- FALSE
-                        warning("Mismatch between geno and founder_geno in no. markers on chr ", names(geno)[i])
                     }
                     else if(any(colnames(geno[[i]]) != colnames(founder_geno[[i]]))) {
                         result <- FALSE

--- a/R/check_cross2.R
+++ b/R/check_cross2.R
@@ -341,6 +341,13 @@ function(cross2)
                 for(i in seq(along=geno)) {
                     if(!check_founder_geno_size(crosstype, founder_geno[[i]], ncol(geno[[i]]))) {
                         result <- FALSE
+                        break
+                    }
+                }
+                for(i in seq(along=geno)) {
+                    if(ncol(geno[[i]]) != ncol(founder_geno[[i]])) {
+                        result <- FALSE
+                        warning("Mismatch in number of markers between geno and founder_geno on chr ", names(geno)[i])
                     }
                     else if(any(colnames(geno[[i]]) != colnames(founder_geno[[i]]))) {
                         result <- FALSE

--- a/src/RcppExports.cpp
+++ b/src/RcppExports.cpp
@@ -627,6 +627,19 @@ BEGIN_RCPP
     return rcpp_result_gen;
 END_RCPP
 }
+// check_founder_geno_size
+bool check_founder_geno_size(const String& crosstype, const IntegerMatrix& founder_geno, const int n_markers);
+RcppExport SEXP qtl2geno_check_founder_geno_size(SEXP crosstypeSEXP, SEXP founder_genoSEXP, SEXP n_markersSEXP) {
+BEGIN_RCPP
+    Rcpp::RObject rcpp_result_gen;
+    Rcpp::RNGScope rcpp_rngScope_gen;
+    Rcpp::traits::input_parameter< const String& >::type crosstype(crosstypeSEXP);
+    Rcpp::traits::input_parameter< const IntegerMatrix& >::type founder_geno(founder_genoSEXP);
+    Rcpp::traits::input_parameter< const int >::type n_markers(n_markersSEXP);
+    rcpp_result_gen = Rcpp::wrap(check_founder_geno_size(crosstype, founder_geno, n_markers));
+    return rcpp_result_gen;
+END_RCPP
+}
 // test_emitmatrix
 std::vector<NumericMatrix> test_emitmatrix(const String& crosstype, const double error_prob, const int max_obsgeno, const IntegerMatrix& founder_geno, const bool is_x_chr, const bool is_female, const IntegerVector& cross_info);
 RcppExport SEXP qtl2geno_test_emitmatrix(SEXP crosstypeSEXP, SEXP error_probSEXP, SEXP max_obsgenoSEXP, SEXP founder_genoSEXP, SEXP is_x_chrSEXP, SEXP is_femaleSEXP, SEXP cross_infoSEXP) {

--- a/src/cross.cpp
+++ b/src/cross.cpp
@@ -30,6 +30,7 @@
 #include "cross_risib4.h"
 #include "cross_risib8.h"
 #include "cross_magic19.h"
+#include "cross_dh6.h"
 
 QTLCross* QTLCross::Create(const String& crosstype)
 {
@@ -53,6 +54,7 @@ QTLCross* QTLCross::Create(const String& crosstype)
     if(crosstype=="risib4")  return new RISIB4();
     if(crosstype=="risib8")  return new RISIB8();
     if(crosstype=="magic19") return new MAGIC19();
+    if(crosstype=="dh6")     return new DH6();
 
     throw std::range_error("cross type not yet supported.");
     return NULL;

--- a/src/cross.cpp
+++ b/src/cross.cpp
@@ -31,6 +31,8 @@
 #include "cross_risib8.h"
 #include "cross_magic19.h"
 #include "cross_dh6.h"
+#include "cross_ail3.h"
+#include "cross_ail3pk.h"
 
 QTLCross* QTLCross::Create(const String& crosstype)
 {
@@ -55,6 +57,8 @@ QTLCross* QTLCross::Create(const String& crosstype)
     if(crosstype=="risib8")  return new RISIB8();
     if(crosstype=="magic19") return new MAGIC19();
     if(crosstype=="dh6")     return new DH6();
+    if(crosstype=="ail3")    return new AIL3();
+    if(crosstype=="ail3pk")  return new AIL3PK();
 
     throw std::range_error("cross type not yet supported.");
     return NULL;

--- a/src/cross_ail.cpp
+++ b/src/cross_ail.cpp
@@ -93,8 +93,8 @@ const double AIL::init(const int true_gen,
 }
 
 const double AIL::emit(const int obs_gen, const int true_gen, const double error_prob,
-                      const IntegerVector& founder_geno, const bool is_x_chr,
-                      const bool is_female, const IntegerVector& cross_info)
+                       const IntegerVector& founder_geno, const bool is_x_chr,
+                       const bool is_female, const IntegerVector& cross_info)
 {
     #ifndef NDEBUG
     if(!check_geno(true_gen, false, is_x_chr, is_female, cross_info))
@@ -141,8 +141,8 @@ const double AIL::emit(const int obs_gen, const int true_gen, const double error
 
 
 const double AIL::step(const int gen_left, const int gen_right, const double rec_frac,
-                      const bool is_x_chr, const bool is_female,
-                      const IntegerVector& cross_info)
+                       const bool is_x_chr, const bool is_female,
+                       const IntegerVector& cross_info)
 {
     #ifndef NDEBUG
     if(!check_geno(gen_left, false, is_x_chr, is_female, cross_info) ||
@@ -335,7 +335,7 @@ const double AIL::step(const int gen_left, const int gen_right, const double rec
 }
 
 const IntegerVector AIL::possible_gen(const bool is_x_chr, const bool is_female,
-                                     const IntegerVector& cross_info)
+                                      const IntegerVector& cross_info)
 {
     if(is_x_chr && !is_female) { // male X chromosome
         IntegerVector result = IntegerVector::create(AY,BY);

--- a/src/cross_ail3.cpp
+++ b/src/cross_ail3.cpp
@@ -21,7 +21,6 @@ const bool AIL3::check_geno(const int gen, const bool is_observed_value,
         else return false;
     }
 
-    const int n_alleles = 3;
     const int n_genoA = 6;
     const int n_genoX = 9;
 
@@ -44,11 +43,6 @@ const double AIL3::init(const int true_gen,
         throw std::range_error("genotype value not allowed");
     #endif
 
-    const int n_alleles = 3;
-    const int n_genoA = 6;
-    const int n_genoX = 9;
-
-
     if(!is_x_chr || is_female) { // autosome or female X
         if(mpp_is_het(true_gen, 3, false)) return log(2.0)-log(9.0);
         else return log(1.0)-log(9.0);
@@ -67,7 +61,6 @@ const double AIL3::emit(const int obs_gen, const int true_gen, const double erro
         throw std::range_error("genotype value not allowed");
     #endif
 
-    const int n_alleles = 3;
     const int n_geno = 6;
 
     if(obs_gen==0) return 0.0; // missing

--- a/src/cross_ail3.cpp
+++ b/src/cross_ail3.cpp
@@ -1,0 +1,457 @@
+// AIL3 (3-way advanced intercross lines) QTLCross class (for HMM)
+// (assuming all F1 hybrids formed followed by random mating with large population)
+
+#include "cross_ail3.h"
+#include <math.h>
+#include <Rcpp.h>
+#include "cross.h"
+#include "cross_util.h" // mpp_encode_alleles and mpp_decode_geno
+#include "r_message.h"
+
+enum gen {AA=1, AB=2, BB=3, notA=5, notB=4,
+          A=1, H=2, B=3};
+
+const bool AIL3::check_geno(const int gen, const bool is_observed_value,
+                            const bool is_x_chr, const bool is_female, const IntegerVector& cross_info)
+{
+    // allow any value 0-5 for observed
+    if(is_observed_value) {
+        if(gen==0 || gen==AA || gen==AB || gen==BB ||
+           gen==notA || gen==notB) return true;
+        else return false;
+    }
+
+    const int n_alleles = 3;
+    const int n_genoA = 6;
+    const int n_genoX = 9;
+
+    if(!is_x_chr || is_female) {// autosome or female X
+        if(gen >= 1 && gen <= n_genoA) return true;
+    }
+    else { // male X
+        if(gen > n_genoA && gen <= n_genoX) return true;
+    }
+
+    return false; // otherwise a problem
+}
+
+const double AIL3::init(const int true_gen,
+                        const bool is_x_chr, const bool is_female,
+                        const IntegerVector& cross_info)
+{
+    #ifndef NDEBUG
+    if(!check_geno(true_gen, false, is_x_chr, is_female, cross_info))
+        throw std::range_error("genotype value not allowed");
+    #endif
+
+    const int n_alleles = 3;
+    const int n_genoA = 6;
+    const int n_genoX = 9;
+
+
+    if(!is_x_chr || is_female) { // autosome or female X
+        if(mpp_is_het(true_gen, 3, false)) return log(2.0)-log(9.0);
+        else return log(1.0)-log(9.0);
+    }
+    else { // male X
+        return -log(3.0);
+    }
+}
+
+const double AIL3::emit(const int obs_gen, const int true_gen, const double error_prob,
+                        const IntegerVector& founder_geno, const bool is_x_chr,
+                        const bool is_female, const IntegerVector& cross_info)
+{
+    #ifndef NDEBUG
+    if(!check_geno(true_gen, false, is_x_chr, is_female, cross_info))
+        throw std::range_error("genotype value not allowed");
+    #endif
+
+    const int n_alleles = 3;
+    const int n_geno = 6;
+
+    if(obs_gen==0) return 0.0; // missing
+
+    if(!is_x_chr || is_female) { // autosome or female X
+        const IntegerVector true_alleles = mpp_decode_geno(true_gen, 3, false);
+        int f1 = founder_geno[true_alleles[0]-1];
+        int f2 = founder_geno[true_alleles[1]-1];
+
+        // treat founder hets as missing
+        if(f1==2) f1 = 0;
+        if(f2==2) f2 = 0;
+
+        // neither founder alleles observed
+        if(f1 == 0 && f2 == 0) return 0.0;
+
+        // one founder allele observed
+        if(f1 == 0 || f2 == 0) {
+
+            switch(std::max(f1, f2)) {
+            case H: return 0.0; // het compatible with either founder allele
+            case A:
+                switch(obs_gen) {
+                case A: case notB: return log(1.0-error_prob);
+                case B: case notA: return log(error_prob);
+                case H: return 0.0;
+                }
+            case B:
+                switch(obs_gen) {
+                case B: case notA: return log(1.0-error_prob);
+                case A: case notB: return log(error_prob);
+                case H: return 0.0;
+                }
+            }
+            return 0.0;
+        }
+
+        switch((f1+f2)/2) { // values 1, 2, 3
+        case A:
+            switch(obs_gen) {
+            case A: return log(1.0-error_prob);
+            case H: return log(error_prob/2.0);
+            case B: return log(error_prob/2.0);
+            case notA: return log(error_prob);
+            case notB: return log(1.0-error_prob/2.0);
+            }
+        case H:
+            switch(obs_gen) {
+            case A: return log(error_prob/2.0);
+            case H: return log(1.0-error_prob);
+            case B: return log(error_prob/2.0);
+            case notA: return log(1.0-error_prob/2.0);
+            case notB: return log(1.0-error_prob/2.0);
+            }
+        case B:
+            switch(obs_gen) {
+            case B: return log(1.0-error_prob);
+            case H: return log(error_prob/2.0);
+            case A: return log(error_prob/2.0);
+            case notB: return log(error_prob);
+            case notA: return log(1.0-error_prob/2.0);
+            }
+        }
+        return 0.0;
+    }
+    else { // male X
+        const int founder_allele = founder_geno[(true_gen - n_geno) - 1];
+
+        switch(founder_allele) {
+        case A:
+            switch(obs_gen) {
+            case A: case notB: return log(1.0-error_prob);
+            case B: case notA: return log(error_prob);
+            }
+        case B:
+            switch(obs_gen) {
+            case B: case notA: return log(1.0-error_prob);
+            case A: case notB: return log(error_prob);
+            }
+        }
+        return(0.0);
+    }
+
+    return NA_REAL; // shouldn't get here
+}
+
+
+const double AIL3::step(const int gen_left, const int gen_right, const double rec_frac,
+                        const bool is_x_chr, const bool is_female,
+                        const IntegerVector& cross_info)
+{
+    #ifndef NDEBUG
+    if(!check_geno(gen_left, false, is_x_chr, is_female, cross_info) ||
+       !check_geno(gen_right, false, is_x_chr, is_female, cross_info))
+        throw std::range_error("genotype value not allowed");
+    #endif
+
+    const int n_gen = cross_info[0]; // number of generations
+
+    if(is_x_chr && !is_female) { // male X
+        const double z = sqrt((1.0-rec_frac)*(9.0-rec_frac));
+        const double pAA = (1.0-rec_frac)/3.0 * ( (1.0-rec_frac+z)/(2.0*z) * pow((1.0-rec_frac-z)/4.0, (double)(n_gen-2)) +
+                                                  (-1.0+rec_frac+z)/(2.0*z) * pow((1.0-rec_frac+z)/4.0, (double)(n_gen-2))) +
+            (2.0-rec_frac)/(2.0*3) * ( (1.0-rec_frac-z)/2.0 * (1.0-rec_frac+z)/(2.0*z) * pow((1.0-rec_frac-z)/4.0,(double)(n_gen-2)) +
+                                       (1.0-rec_frac+z)/2.0 * (-1.0+rec_frac+z)/(2.0*z) * pow((1.0-rec_frac+z)/4.0,(double)(n_gen-2))) +
+            ( (rec_frac*rec_frac + rec_frac*(z-5.0))/(9*(3.0+rec_frac+z)) * (1.0-rec_frac+z)/(2.0*z) * pow((1.0-rec_frac-z)/4.0,(double)(n_gen-2)) +
+              (rec_frac*rec_frac - rec_frac*(z+5.0))/(9*(3.0+rec_frac-z)) * (-1.0+rec_frac+z)/(2.0*z) * pow((1.0-rec_frac+z)/4.0,(double)(n_gen-2)) + 1.0/9.0);
+        const double R = (1.0-3.0*pAA);
+
+        if(gen_left == gen_right) return log1p(-R);
+        return log(R) - log(2.0);
+    }
+    else { // autosome or female X
+        double pAA;
+        if(!is_x_chr) { // autosome
+            pAA = (1.0 - (-2.0 + 3.0*rec_frac)*pow(1.0 - rec_frac, (double)(n_gen-2)))/9.0;
+        }
+        else { // female X
+            const double z = sqrt((1.0-rec_frac)*(9.0-rec_frac));
+
+            pAA = (1.0-rec_frac)/3.0 * ( (-1.0/z)*pow((1.0-rec_frac-z)/4.0,(double)(n_gen-2)) +
+                                         (1.0/z)*pow((1.0-rec_frac+z)/4.0,(double)(n_gen-2))) +
+                (2.0-rec_frac)/6.0 * ( (1.0-rec_frac-z)/2.0 * (-1.0/z)*pow((1.0-rec_frac-z)/4.0,(double)(n_gen-2)) +
+                                       (1.0-rec_frac+z)/2.0 *  (1.0/z)*pow((1.0-rec_frac+z)/4.0,(double)(n_gen-2))) +
+                ( (rec_frac*rec_frac + rec_frac*(z-5.0))/(9.0*(3.0+rec_frac+z)) * (-1.0/z)*pow((1.0-rec_frac-z)/4.0,(double)(n_gen-2)) +
+                  (rec_frac*rec_frac - rec_frac*(z+5.0))/(9.0*(3.0+rec_frac-z)) * (1.0/z)*pow((1.0-rec_frac+z)/4.0,(double)(n_gen-2))  + 1.0/9.0);
+        }
+        double R = (1.0 - 3.0*pAA);
+
+        const IntegerVector alleles_left = mpp_decode_geno(gen_left, 3, false);
+        const IntegerVector alleles_right = mpp_decode_geno(gen_right, 3, false);
+
+        if(alleles_left[0] == alleles_left[1]) { // homozygous
+            if(alleles_right[0] == alleles_right[1]) { // homozygous
+                if(alleles_left[0] == alleles_right[0]) { // AA -> AA
+                    return 2.0*log(1.0-R);
+                }
+                else { // AA -> BB
+                    return 2.0*(log(R) - log(2.0));
+                }
+            }
+            else {
+                if(alleles_left[0] == alleles_right[0] ||
+                   alleles_left[0] == alleles_right[1]) { // AA -> AB
+                    return log(1.0-R) + log(R) - log(2.0);
+                }
+                else { // AA -> BC
+                    return 2.0*(log(R)-log(2.0));
+                }
+            }
+        }
+        else {
+            if(alleles_right[0] == alleles_right[1]) { // homozygous
+                if(alleles_left[0] == alleles_right[0] ||
+                   alleles_left[1] == alleles_right[1]) { // AB -> AA
+                    return log(1.0-R) + log(R) - log(2.0);
+                }
+                else { // AB -> CC
+                    return 2.0*(log(R) - log(2.0));
+                }
+            }
+            else {
+                if((alleles_left[0] == alleles_right[0] &&
+                    alleles_left[1] == alleles_right[1]) ||
+                   (alleles_left[0] == alleles_right[1] &&
+                    alleles_left[1] == alleles_right[0])) { // AB -> AB
+                    return log((1.0-R)*(1.0-R) + R*R/4.0);
+                }
+                else { // AB -> BC  (R/2)^2 + (R/2)*(1-R) = (R/2)*(1-R/2)
+                    return log(R) - log(2.0) + log(1.0 - R/2.0);
+                }
+            }
+        }
+
+    }
+
+    return NA_REAL; // shouldn't get here
+}
+
+const IntegerVector AIL3::possible_gen(const bool is_x_chr, const bool is_female,
+                                     const IntegerVector& cross_info)
+{
+    if(is_x_chr && !is_female) { // male X chromosome
+        IntegerVector result = IntegerVector::create(7,8,9);
+        return result;
+    }
+    else { // autosome or female X
+        IntegerVector result = IntegerVector::create(1,2,3,4,5,6);
+        return result;
+    }
+}
+
+const int AIL3::ngen(const bool is_x_chr)
+{
+    if(is_x_chr) return 9;
+    return 6;
+}
+
+const int AIL3::nalleles()
+{
+    return 3;
+}
+
+const NumericMatrix AIL3::geno2allele_matrix(const bool is_x_chr)
+{
+    if(is_x_chr) {
+        NumericMatrix result(9,3);
+        result(0,0) = 1.0;               // AA female
+        result(1,0) = result(1,1) = 0.5; // AB female
+        result(2,1) = 1.0;               // BB female
+        result(3,0) = result(3,2) = 0.5; // AC female
+        result(4,1) = result(4,2) = 0.5; // BC female
+        result(5,2) = 1.0;               // CC female
+
+        result(6,0) = 1.0; // AY male
+        result(7,1) = 1.0; // BY male
+        result(8,2) = 1.0; // CY male
+
+        return result;
+    }
+    else {
+        NumericMatrix result(6,3);
+        result(0,0) = 1.0;               // AA
+        result(1,0) = result(1,1) = 0.5; // AB
+        result(2,1) = 1.0;               // BB
+        result(3,0) = result(3,2) = 0.5; // AC
+        result(4,1) = result(4,2) = 0.5; // BC
+        result(5,2) = 1.0;               // CC
+
+        return result;
+    }
+}
+
+// check that sex conforms to expectation
+const bool AIL3::check_is_female_vector(const LogicalVector& is_female, const bool any_x_chr)
+{
+    bool result = true;
+    const int n = is_female.size();
+    if(!any_x_chr) { // all autosomes
+        if(n > 0) {
+            // not needed here, but don't call it an error
+            result = true;
+        }
+    }
+    else { // X chr included
+        if(n == 0) {
+            result = false;
+            r_message("is_female not provided, but needed to handle X chromosome");
+        }
+        else {
+            int n_missing = 0;
+            for(int i=0; i<n; i++)
+                if(is_female[i] == NA_LOGICAL) ++n_missing;
+            if(n_missing > 0) {
+                result = false;
+                r_message("is_female contains missing values (it shouldn't)");
+            }
+        }
+    }
+    return result;
+}
+
+// check that cross_info conforms to expectation
+const bool AIL3::check_crossinfo(const IntegerMatrix& cross_info, const bool any_x_chr)
+{
+    bool result = true;
+    const int n_row = cross_info.rows();
+    const int n_col = cross_info.cols();
+    // single column with number of generations (needed no matter what; values should be >= 2)
+
+    if(n_col != 1) {
+        result = false;
+        r_message("cross_info should have one column, with no. generations");
+        return result;
+    }
+
+    int n_missing=0;
+    int n_invalid=0;
+    for(int i=0; i<n_row; i++) {
+        if(cross_info[i] == NA_INTEGER) ++n_missing;
+        else if(cross_info[i] < 2) ++n_invalid;
+    }
+    if(n_missing > 0) {
+        result = false;
+        r_message("cross_info has missing values (it shouldn't)");
+    }
+    if(n_invalid > 0) {
+        result = false;
+        r_message("cross_info has invalid values; no. generations should be >= 2");
+    }
+
+    return result;
+}
+
+// geno_names from allele names
+const std::vector<std::string> AIL3::geno_names(const std::vector<std::string> alleles,
+                                                const bool is_x_chr)
+{
+    if(alleles.size() != 3)
+        throw std::range_error("alleles must have length 3");
+
+    if(is_x_chr) {
+        std::vector<std::string> result(9);
+        result[0] = alleles[0] + alleles[0];
+        result[1] = alleles[0] + alleles[1];
+        result[2] = alleles[1] + alleles[1];
+        result[3] = alleles[0] + alleles[2];
+        result[4] = alleles[1] + alleles[2];
+        result[5] = alleles[2] + alleles[2];
+        result[6] = alleles[0] + "Y";
+        result[7] = alleles[1] + "Y";
+        result[8] = alleles[2] + "Y";
+        return result;
+    }
+    else {
+        std::vector<std::string> result(6);
+        result[0] = alleles[0] + alleles[0];
+        result[1] = alleles[0] + alleles[1];
+        result[2] = alleles[1] + alleles[1];
+        result[3] = alleles[0] + alleles[2];
+        result[4] = alleles[1] + alleles[2];
+        result[5] = alleles[2] + alleles[2];
+        return result;
+    }
+}
+
+// used in counting crossovers in count_xo.R and locate_xo.R
+const int AIL3::nrec(const int gen_left, const int gen_right,
+                     const bool is_x_chr, const bool is_female,
+                     const Rcpp::IntegerVector& cross_info)
+{
+    #ifndef NDEBUG
+    if(!check_geno(gen_left, false, is_x_chr, is_female, cross_info) ||
+       !check_geno(gen_right, false, is_x_chr, is_female, cross_info))
+        throw std::range_error("genotype value not allowed");
+    #endif
+
+    if(is_x_chr && gen_left > 6 && gen_right > 6) { // male X
+        if(gen_left == gen_right) return(0);
+        else return(1);
+    }
+
+    // otherwise autosome or female X
+    Rcpp::IntegerVector a_left = mpp_decode_geno(gen_left, 3, false);
+    Rcpp::IntegerVector a_right = mpp_decode_geno(gen_right, 3, false);
+
+    if(a_left[0] == a_right[0]) {
+        if(a_left[1] == a_right[1]) return(0);
+        else return(1);
+    }
+    else if(a_left[0] == a_right[1]) {
+        if(a_left[1] == a_right[0]) return(0);
+        else return(1);
+    }
+    else if(a_left[1] == a_right[0]) {
+        return(1);
+    }
+    else if(a_left[1] == a_right[1]) {
+        return(1);
+    }
+    else return(2);
+
+    return(NA_INTEGER);
+}
+
+// not implemented
+const NumericVector AIL3::est_map2(const IntegerMatrix& genotypes,
+                                   const IntegerMatrix& founder_geno,
+                                   const bool is_X_chr,
+                                   const LogicalVector& is_female,
+                                   const IntegerMatrix& cross_info,
+                                   const IntegerVector& cross_group,
+                                   const IntegerVector& unique_cross_group,
+                                   const NumericVector& rec_frac,
+                                   const double error_prob,
+                                   const int max_iterations,
+                                   const double tol,
+                                   const bool verbose)
+{
+    Rcpp::stop("est_map not yet implemented for 3-way AILs.");
+
+    // return vector of NAs
+    const int n_rf = rec_frac.size();
+    NumericVector result(n_rf);
+    for(int i=0; i<n_rf; i++) result[i] = NA_REAL;
+    return result ;
+}

--- a/src/cross_ail3.h
+++ b/src/cross_ail3.h
@@ -1,0 +1,64 @@
+// AIL3 (3-way advanced intercross lines) QTLCross class (for HMM)
+// (assuming all F1 hybrids formed followed by random mating with large population)
+
+#ifndef CROSS_AIL3_H
+#define CROSS_AIL3_H
+
+#include <Rcpp.h>
+#include "cross.h"
+
+class AIL3 : public QTLCross
+{
+ public:
+    AIL3(){
+        crosstype = "ail3";
+        phase_known_crosstype = "ail3pk";
+    };
+    ~AIL3(){};
+
+    const bool check_geno(const int gen, const bool is_observed_value,
+                          const bool is_x_chr, const bool is_female, const Rcpp::IntegerVector& cross_info);
+
+    const double init(const int true_gen,
+                      const bool is_x_chr, const bool is_female, const Rcpp::IntegerVector& cross_info);
+    const double emit(const int obs_gen, const int true_gen, const double error_prob,
+                      const Rcpp::IntegerVector& founder_geno, const bool is_x_chr,
+                      const bool is_female, const Rcpp::IntegerVector& cross_info);
+    const double step(const int gen_left, const int gen_right, const double rec_frac,
+                      const bool is_x_chr, const bool is_female, const Rcpp::IntegerVector& cross_info);
+
+    const Rcpp::IntegerVector possible_gen(const bool is_x_chr, const bool is_female, const Rcpp::IntegerVector& cross_info);
+
+    const int ngen(const bool is_x_chr);
+
+    const int nalleles();
+
+    const Rcpp::NumericMatrix geno2allele_matrix(const bool is_x_chr);
+
+    const bool check_is_female_vector(const Rcpp::LogicalVector& is_female, const bool any_x_chr);
+
+    const bool check_crossinfo(const Rcpp::IntegerMatrix& cross_info, const bool any_x_chr);
+
+    const std::vector<std::string> geno_names(const std::vector<std::string> alleles, const bool is_x_chr);
+
+    const int nrec(const int gen_left, const int gen_right,
+                   const bool is_x_chr, const bool is_female,
+                   const Rcpp::IntegerVector& cross_info);
+
+    // not yet implemented
+    const Rcpp::NumericVector est_map2(const Rcpp::IntegerMatrix& genotypes,
+                                       const Rcpp::IntegerMatrix& founder_geno,
+                                       const bool is_X_chr,
+                                       const Rcpp::LogicalVector& is_female,
+                                       const Rcpp::IntegerMatrix& cross_info,
+                                       const Rcpp::IntegerVector& cross_group,
+                                       const Rcpp::IntegerVector& unique_cross_group,
+                                       const Rcpp::NumericVector& rec_frac,
+                                       const double error_prob,
+                                       const int max_iterations,
+                                       const double tol,
+                                       const bool verbose);
+
+};
+
+#endif // CROSS_AIL3_H

--- a/src/cross_ail3pk.cpp
+++ b/src/cross_ail3pk.cpp
@@ -21,7 +21,6 @@ const bool AIL3PK::check_geno(const int gen, const bool is_observed_value,
         else return false;
     }
 
-    const int n_alleles = 3;
     const int n_genoA = 9;
     const int n_genoX = 12;
 
@@ -63,7 +62,6 @@ const double AIL3PK::emit(const int obs_gen, const int true_gen, const double er
         throw std::range_error("genotype value not allowed");
     #endif
 
-    const int n_alleles = 3;
     const int n_geno = 9;
 
     if(obs_gen==0) return 0.0; // missing

--- a/src/cross_ail3pk.cpp
+++ b/src/cross_ail3pk.cpp
@@ -45,7 +45,7 @@ const double AIL3PK::init(const int true_gen,
         throw std::range_error("genotype value not allowed");
     #endif
 
-    if(is_x_chr || is_female) { // autosome or female X
+    if(!is_x_chr || is_female) { // autosome or female X
         return -log(9.0);
     }
     else { // male X
@@ -193,8 +193,8 @@ const double AIL3PK::step(const int gen_left, const int gen_right, const double 
         }
         double R = (1.0 - 3.0*pAA);
 
-        const IntegerVector alleles_left = mpp_decode_geno(gen_left, 3, false);
-        const IntegerVector alleles_right = mpp_decode_geno(gen_right, 3, false);
+        const IntegerVector alleles_left = mpp_decode_geno(gen_left, 3, true);
+        const IntegerVector alleles_right = mpp_decode_geno(gen_right, 3, true);
 
         if(alleles_left[0] == alleles_left[1]) { // homozygous
             if(alleles_right[0] == alleles_right[1]) { // homozygous

--- a/src/cross_ail3pk.cpp
+++ b/src/cross_ail3pk.cpp
@@ -1,0 +1,401 @@
+// phase-known AIL3 (3-way advanced intercross lines) QTLCross class (for HMM, in particular est.map)
+// (assuming all F1 hybrids formed followed by random mating with large population)
+
+#include "cross_ail3pk.h"
+#include <math.h>
+#include <Rcpp.h>
+#include "cross.h"
+#include "cross_util.h" // mpp_encode_alleles and mpp_decode_geno
+#include "r_message.h"
+
+enum gen {AA=1, AB=2, BB=3, notA=5, notB=4,
+          A=1, H=2, B=3};
+
+const bool AIL3PK::check_geno(const int gen, const bool is_observed_value,
+                              const bool is_x_chr, const bool is_female, const IntegerVector& cross_info)
+{
+    // allow any value 0-5 for observed
+    if(is_observed_value) {
+        if(gen==0 || gen==AA || gen==AB || gen==BB ||
+           gen==notA || gen==notB) return true;
+        else return false;
+    }
+
+    const int n_alleles = 3;
+    const int n_genoA = 9;
+    const int n_genoX = 12;
+
+    if(!is_x_chr || is_female) { // autosome or female X
+        if(gen >= 1 && gen <= n_genoA) return true;
+    }
+    else { // male X
+        if(gen > n_genoA && gen <= n_genoX) return true;
+    }
+
+    return false; // invalid
+}
+
+
+const double AIL3PK::init(const int true_gen,
+                          const bool is_x_chr, const bool is_female,
+                          const IntegerVector& cross_info)
+{
+    #ifndef NDEBUG
+    if(!check_geno(true_gen, false, is_x_chr, is_female, cross_info))
+        throw std::range_error("genotype value not allowed");
+    #endif
+
+    if(is_x_chr || is_female) { // autosome or female X
+        return -log(9.0);
+    }
+    else { // male X
+        return -log(3.0);
+    }
+}
+
+const double AIL3PK::emit(const int obs_gen, const int true_gen, const double error_prob,
+                          const IntegerVector& founder_geno, const bool is_x_chr,
+                          const bool is_female, const IntegerVector& cross_info)
+{
+
+    #ifndef NDEBUG
+    if(!check_geno(true_gen, false, is_x_chr, is_female, cross_info))
+        throw std::range_error("genotype value not allowed");
+    #endif
+
+    const int n_alleles = 3;
+    const int n_geno = 9;
+
+    if(obs_gen==0) return 0.0; // missing
+
+    if(!is_x_chr || is_female) { // autosome or female X
+        const IntegerVector true_alleles = mpp_decode_geno(true_gen, 3, true);
+        int f1 = founder_geno[true_alleles[0]-1];
+        int f2 = founder_geno[true_alleles[1]-1];
+
+        // treat founder hets as missing
+        if(f1==2) f1 = 0;
+        if(f2==2) f2 = 0;
+
+        // neither founder alleles observed
+        if(f1 == 0 && f2 == 0) return 0.0;
+
+        // one founder allele observed
+        if(f1 == 0 || f2 == 0) {
+
+            switch(std::max(f1, f2)) {
+            case H: return 0.0; // het compatible with either founder allele
+            case A:
+                switch(obs_gen) {
+                case A: case notB: return log(1.0-error_prob);
+                case B: case notA: return log(error_prob);
+                case H: return 0.0;
+                }
+            case B:
+                switch(obs_gen) {
+                case B: case notA: return log(1.0-error_prob);
+                case A: case notB: return log(error_prob);
+                case H: return 0.0;
+                }
+            }
+            return 0.0;
+        }
+
+        switch((f1+f2)/2) { // values 1, 2, 3
+        case A:
+            switch(obs_gen) {
+            case A: return log(1.0-error_prob);
+            case H: return log(error_prob/2.0);
+            case B: return log(error_prob/2.0);
+            case notA: return log(error_prob);
+            case notB: return log(1.0-error_prob/2.0);
+            }
+        case H:
+            switch(obs_gen) {
+            case A: return log(error_prob/2.0);
+            case H: return log(1.0-error_prob);
+            case B: return log(error_prob/2.0);
+            case notA: return log(1.0-error_prob/2.0);
+            case notB: return log(1.0-error_prob/2.0);
+            }
+        case B:
+            switch(obs_gen) {
+            case B: return log(1.0-error_prob);
+            case H: return log(error_prob/2.0);
+            case A: return log(error_prob/2.0);
+            case notB: return log(error_prob);
+            case notA: return log(1.0-error_prob/2.0);
+            }
+        }
+        return 0.0;
+    }
+    else { // male X
+        const int founder_allele = founder_geno[(true_gen - n_geno) - 1];
+
+        switch(founder_allele) {
+        case A:
+            switch(obs_gen) {
+            case A: case notB: return log(1.0-error_prob);
+            case B: case notA: return log(error_prob);
+            }
+        case B:
+            switch(obs_gen) {
+            case B: case notA: return log(1.0-error_prob);
+            case A: case notB: return log(error_prob);
+            }
+        }
+        return(0.0);
+    }
+
+    return NA_REAL; // shouldn't get here
+}
+
+
+const double AIL3PK::step(const int gen_left, const int gen_right, const double rec_frac,
+                          const bool is_x_chr, const bool is_female,
+                          const IntegerVector& cross_info)
+{
+    #ifndef NDEBUG
+    if(!check_geno(gen_left, false, is_x_chr, is_female, cross_info) ||
+       !check_geno(gen_right, false, is_x_chr, is_female, cross_info))
+        throw std::range_error("genotype value not allowed");
+    #endif
+
+    const int n_gen = cross_info[0]; // number of generations
+
+    if(is_x_chr && !is_female) { // male X
+        const double z = sqrt((1.0-rec_frac)*(9.0-rec_frac));
+        const double pAA = (1.0-rec_frac)/3.0 * ( (1.0-rec_frac+z)/(2.0*z) * pow((1.0-rec_frac-z)/4.0, (double)(n_gen-2)) +
+                                                  (-1.0+rec_frac+z)/(2.0*z) * pow((1.0-rec_frac+z)/4.0, (double)(n_gen-2))) +
+            (2.0-rec_frac)/(2.0*3) * ( (1.0-rec_frac-z)/2.0 * (1.0-rec_frac+z)/(2.0*z) * pow((1.0-rec_frac-z)/4.0,(double)(n_gen-2)) +
+                                       (1.0-rec_frac+z)/2.0 * (-1.0+rec_frac+z)/(2.0*z) * pow((1.0-rec_frac+z)/4.0,(double)(n_gen-2))) +
+            ( (rec_frac*rec_frac + rec_frac*(z-5.0))/(9*(3.0+rec_frac+z)) * (1.0-rec_frac+z)/(2.0*z) * pow((1.0-rec_frac-z)/4.0,(double)(n_gen-2)) +
+              (rec_frac*rec_frac - rec_frac*(z+5.0))/(9*(3.0+rec_frac-z)) * (-1.0+rec_frac+z)/(2.0*z) * pow((1.0-rec_frac+z)/4.0,(double)(n_gen-2)) + 1.0/9.0);
+        const double R = (1.0-3.0*pAA);
+
+        if(gen_left == gen_right) return log1p(-R);
+        return log(R) - log(2.0);
+    }
+    else { // autosome or female X
+        double pAA;
+        if(!is_x_chr) { // autosome
+            pAA = (1.0 - (-2.0 + 3.0*rec_frac)*pow(1.0 - rec_frac, (double)(n_gen-2)))/9.0;
+        }
+        else { // female X
+            const double z = sqrt((1.0-rec_frac)*(9.0-rec_frac));
+
+            pAA = (1.0-rec_frac)/3.0 * ( (-1.0/z)*pow((1.0-rec_frac-z)/4.0,(double)(n_gen-2)) +
+                                         (1.0/z)*pow((1.0-rec_frac+z)/4.0,(double)(n_gen-2))) +
+                (2.0-rec_frac)/6.0 * ( (1.0-rec_frac-z)/2.0 * (-1.0/z)*pow((1.0-rec_frac-z)/4.0,(double)(n_gen-2)) +
+                                       (1.0-rec_frac+z)/2.0 *  (1.0/z)*pow((1.0-rec_frac+z)/4.0,(double)(n_gen-2))) +
+                ( (rec_frac*rec_frac + rec_frac*(z-5.0))/(9.0*(3.0+rec_frac+z)) * (-1.0/z)*pow((1.0-rec_frac-z)/4.0,(double)(n_gen-2)) +
+                  (rec_frac*rec_frac - rec_frac*(z+5.0))/(9.0*(3.0+rec_frac-z)) * (1.0/z)*pow((1.0-rec_frac+z)/4.0,(double)(n_gen-2))  + 1.0/9.0);
+        }
+        double R = (1.0 - 3.0*pAA);
+
+        const IntegerVector alleles_left = mpp_decode_geno(gen_left, 3, false);
+        const IntegerVector alleles_right = mpp_decode_geno(gen_right, 3, false);
+
+        if(alleles_left[0] == alleles_left[1]) { // homozygous
+            if(alleles_right[0] == alleles_right[1]) { // homozygous
+                if(alleles_left[0] == alleles_right[0]) { // AA -> AA
+                    return 2.0*log(1.0-R);
+                }
+                else { // AA -> BB
+                    return 2.0*(log(R) - log(2.0));
+                }
+            }
+            else {
+                if(alleles_left[0] == alleles_right[0] ||
+                   alleles_left[0] == alleles_right[1]) { // AA -> AB
+                    return log(1.0-R) + log(R) - log(2.0);
+                }
+                else { // AA -> BC
+                    return 2.0*(log(R)-log(2.0));
+                }
+            }
+        }
+        else {
+            if(alleles_right[0] == alleles_right[1]) { // homozygous
+                if(alleles_left[0] == alleles_right[0] ||
+                   alleles_left[1] == alleles_right[1]) { // AB -> AA
+                    return log(1.0-R) + log(R) - log(2.0);
+                }
+                else { // AB -> CC
+                    return 2.0*(log(R) - log(2.0));
+                }
+            }
+            else { // both het
+                if(alleles_left[0] == alleles_right[0] &&
+                   alleles_left[1] == alleles_right[1]) { // AB -> AB
+                    return 2.0*log(1.0-R);
+                }
+                else if(alleles_left[0] == alleles_right[0] ||
+                        alleles_left[1] == alleles_right[1]) { // AB -> AC
+                    return log(1.0-R) + log(R) - log(2.0);
+                }
+                else { // AB -> BC
+                    return 2.0*(log(R) - log(2.0));
+                }
+            }
+        }
+
+    }
+
+    return NA_REAL; // shouldn't get here
+}
+
+const IntegerVector AIL3PK::possible_gen(const bool is_x_chr, const bool is_female,
+                                         const IntegerVector& cross_info)
+{
+    if(is_x_chr && !is_female) { // male X chromosome
+        IntegerVector result = IntegerVector::create(10, 11, 12);
+        return result;
+    }
+    else { // autosome or female X
+        IntegerVector result = IntegerVector::create(1,2,3,4,5,6,7,8,9);
+        return result;
+    }
+}
+
+const int AIL3PK::ngen(const bool is_x_chr)
+{
+    if(is_x_chr) return 12;
+    return 9;
+}
+
+const int AIL3PK::nalleles()
+{
+    return 3;
+}
+
+const int AIL3PK::nrec(const int gen_left, const int gen_right,
+                       const bool is_x_chr, const bool is_female,
+                       const IntegerVector& cross_info)
+{
+    #ifndef NDEBUG
+    if(!check_geno(gen_left, false, is_x_chr, is_female, cross_info) ||
+       !check_geno(gen_right, false, is_x_chr, is_female, cross_info))
+        throw std::range_error("genotype value not allowed");
+    #endif
+
+    if(is_x_chr && gen_left > 9 && gen_right > 9) { // male X
+        if(gen_left == gen_right) return(0);
+        else return(1);
+    }
+
+    // otherwise autosome or female X
+    Rcpp::IntegerVector a_left = mpp_decode_geno(gen_left, 3, true);
+    Rcpp::IntegerVector a_right = mpp_decode_geno(gen_right, 3, true);
+
+    int result = 0;
+    if(a_left[0] != a_right[0]) result++;
+    if(a_left[1] != a_right[1]) result++;
+    return result;
+}
+
+const double AIL3PK::est_rec_frac(const NumericVector& gamma, const bool is_x_chr,
+                                  const IntegerMatrix& cross_info, const int n_gen)
+{
+    Rcpp::stop("est_map not yet available for 3-way AIL");
+
+    return NA_REAL;
+}
+
+
+const NumericMatrix AIL3PK::geno2allele_matrix(const bool is_x_chr)
+{
+    if(is_x_chr) {
+        NumericMatrix result(12,3);
+        result(0,0) = 1.0;               // AA female
+        result(1,0) = result(1,1) = 0.5; // AB female
+        result(2,1) = 1.0;               // BB female
+        result(3,0) = result(3,2) = 0.5; // AC female
+        result(4,1) = result(4,2) = 0.5; // BC female
+        result(5,2) = 1.0;               // CC female
+        result(6,1) = result(6,0) = 0.5; // BA female
+        result(7,2) = result(7,0) = 0.5; // CA female
+        result(8,2) = result(8,1) = 0.5; // CB female
+
+        result(9, 0) = 1.0; // AY male
+        result(10,1) = 1.0; // BY male
+        result(11,2) = 1.0; // CY male
+
+        return result;
+    }
+    else {
+        NumericMatrix result(9,3);
+        result(0,0) = 1.0;               // AA
+        result(1,0) = result(1,1) = 0.5; // AB
+        result(2,1) = 1.0;               // BB
+        result(3,0) = result(3,2) = 0.5; // AC
+        result(4,1) = result(4,2) = 0.5; // BC
+        result(5,2) = 1.0;               // CC
+        result(6,1) = result(6,0) = 0.5; // BA
+        result(7,2) = result(7,0) = 0.5; // CA
+        result(8,2) = result(8,1) = 0.5; // CB
+
+        return result;
+    }
+}
+
+// check that sex conforms to expectation
+const bool AIL3PK::check_is_female_vector(const LogicalVector& is_female, const bool any_x_chr)
+{
+    bool result = true;
+    const int n = is_female.size();
+    if(!any_x_chr) { // all autosomes
+        if(n > 0) {
+            // not needed here, but don't call this an error
+            result = true;
+        }
+    }
+    else { // X chr included
+        if(n == 0) {
+            result = false;
+            r_message("is_female not provided, but needed to handle X chromosome");
+        }
+        else {
+            int n_missing = 0;
+            for(int i=0; i<n; i++)
+                if(is_female[i] == NA_LOGICAL) ++n_missing;
+            if(n_missing > 0) {
+                result = false;
+                r_message("is_female contains missing values (it shouldn't)");
+            }
+        }
+    }
+    return result;
+}
+
+// check that cross_info conforms to expectation
+const bool AIL3PK::check_crossinfo(const IntegerMatrix& cross_info, const bool any_x_chr)
+{
+    bool result = true;
+    const int n_row = cross_info.rows();
+    const int n_col = cross_info.cols();
+    // single column with number of generations (needed no matter what; values should be >= 2)
+
+    if(n_col != 1) {
+        result = false;
+        r_message("cross_info should have one column, with no. generations");
+        return result;
+    }
+
+    int n_missing=0;
+    int n_invalid=0;
+    for(int i=0; i<n_row; i++) {
+        if(cross_info[i] == NA_INTEGER) ++n_missing;
+        else if(cross_info[i] < 2) ++n_invalid;
+    }
+    if(n_missing > 0) {
+        result = false;
+        r_message("cross_info has missing values (it shouldn't)");
+    }
+    if(n_invalid > 0) {
+        result = false;
+        r_message("cross_info has invalid values; no. generations should be >= 2");
+    }
+
+    return result;
+}

--- a/src/cross_ail3pk.h
+++ b/src/cross_ail3pk.h
@@ -1,0 +1,57 @@
+// phase-known AIL3 (3-way advanced intercross lines) QTLCross class (for HMM, in particular est.map)
+// (assuming all F1 hybrids formed followed by random mating with large population)
+
+#ifndef CROSS_AIL3PK_H
+#define CROSS_AIL3PK_H
+
+#include <Rcpp.h>
+#include "cross.h"
+
+class AIL3PK : public QTLCross
+{
+ public:
+    AIL3PK(){
+        crosstype = "ail3pk";
+        phase_known_crosstype = "ail3pk";
+    };
+    ~AIL3PK(){};
+
+    const bool check_geno(const int gen, const bool is_observed_value,
+                          const bool is_x_chr, const bool is_female, const Rcpp::IntegerVector& cross_info);
+
+    const double init(const int true_gen,
+                      const bool is_x_chr, const bool is_female, const Rcpp::IntegerVector& cross_info);
+    const double emit(const int obs_gen, const int true_gen, const double error_prob,
+                      const Rcpp::IntegerVector& founder_geno, const bool is_x_chr,
+                      const bool is_female, const Rcpp::IntegerVector& cross_info);
+    const double step(const int gen_left, const int gen_right, const double rec_frac,
+                      const bool is_x_chr, const bool is_female, const Rcpp::IntegerVector& cross_info);
+
+    const Rcpp::IntegerVector possible_gen(const bool is_x_chr, const bool is_female, const Rcpp::IntegerVector& cross_info);
+
+    const int ngen(const bool is_x_chr);
+
+    const int nalleles();
+
+    const int nrec(const int gen_left, const int gen_right,
+                   const bool is_x_chr, const bool is_female, const Rcpp::IntegerVector& cross_info);
+
+    // this isn't actually implemented yet; just throws an error
+    const double est_rec_frac(const Rcpp::NumericVector& gamma, const bool is_x_chr,
+                              const Rcpp::IntegerMatrix& cross_info, const int n_gen);
+
+    // this is to indicate that the f2pk cross type shouldn't exist on the R side
+    // (it's strictly a device for using phase-known version for est_map)
+    const bool crosstype_supported() {
+        return false;
+    }
+
+    const Rcpp::NumericMatrix geno2allele_matrix(const bool is_x_chr);
+
+    const bool check_is_female_vector(const Rcpp::LogicalVector& is_female, const bool any_x_chr);
+
+    const bool check_crossinfo(const Rcpp::IntegerMatrix& cross_info, const bool any_x_chr);
+
+};
+
+#endif // CROSS_AIL3PK_H

--- a/src/cross_ailpk.cpp
+++ b/src/cross_ailpk.cpp
@@ -11,7 +11,7 @@ enum gen {AA=1, AB=2, BA=3, BB=4,
           AY=5, BY=6};
 
 const bool AILPK::check_geno(const int gen, const bool is_observed_value,
-                            const bool is_x_chr, const bool is_female, const IntegerVector& cross_info)
+                             const bool is_x_chr, const bool is_female, const IntegerVector& cross_info)
 {
     // allow any value 0-5 or observed
     if(is_observed_value) {
@@ -32,8 +32,8 @@ const bool AILPK::check_geno(const int gen, const bool is_observed_value,
 
 
 const double AILPK::init(const int true_gen,
-                        const bool is_x_chr, const bool is_female,
-                        const IntegerVector& cross_info)
+                         const bool is_x_chr, const bool is_female,
+                         const IntegerVector& cross_info)
 {
     #ifndef NDEBUG
     if(!check_geno(true_gen, false, is_x_chr, is_female, cross_info))
@@ -92,8 +92,8 @@ const double AILPK::init(const int true_gen,
 }
 
 const double AILPK::emit(const int obs_gen, const int true_gen, const double error_prob,
-                        const IntegerVector& founder_geno, const bool is_x_chr,
-                        const bool is_female, const IntegerVector& cross_info)
+                         const IntegerVector& founder_geno, const bool is_x_chr,
+                         const bool is_female, const IntegerVector& cross_info)
 {
 
     #ifndef NDEBUG
@@ -141,8 +141,8 @@ const double AILPK::emit(const int obs_gen, const int true_gen, const double err
 
 
 const double AILPK::step(const int gen_left, const int gen_right, const double rec_frac,
-                        const bool is_x_chr, const bool is_female,
-                        const IntegerVector& cross_info)
+                         const bool is_x_chr, const bool is_female,
+                         const IntegerVector& cross_info)
 {
     #ifndef NDEBUG
     if(!check_geno(gen_left, false, is_x_chr, is_female, cross_info) ||
@@ -365,7 +365,7 @@ const double AILPK::step(const int gen_left, const int gen_right, const double r
 }
 
 const IntegerVector AILPK::possible_gen(const bool is_x_chr, const bool is_female,
-                                       const IntegerVector& cross_info)
+                                        const IntegerVector& cross_info)
 {
     if(is_x_chr && !is_female) { // male X chromosome
         IntegerVector result = IntegerVector::create(AY,BY);
@@ -384,8 +384,8 @@ const int AILPK::ngen(const bool is_x_chr)
 }
 
 const int AILPK::nrec(const int gen_left, const int gen_right,
-                        const bool is_x_chr, const bool is_female,
-                        const IntegerVector& cross_info)
+                      const bool is_x_chr, const bool is_female,
+                      const IntegerVector& cross_info)
 {
     #ifndef NDEBUG
     if(!check_geno(gen_left, false, is_x_chr, is_female, cross_info) ||
@@ -430,7 +430,7 @@ const int AILPK::nrec(const int gen_left, const int gen_right,
 }
 
 const double AILPK::est_rec_frac(const NumericVector& gamma, const bool is_x_chr,
-                                const IntegerMatrix& cross_info, const int n_gen)
+                                 const IntegerMatrix& cross_info, const int n_gen)
 {
     Rcpp::stop("est_map not yet available for AIL");
 

--- a/src/cross_dh6.cpp
+++ b/src/cross_dh6.cpp
@@ -71,9 +71,9 @@ const double DH6::step(const int gen_left, const int gen_right, const double rec
         throw std::range_error("genotype value not allowed");
     #endif
 
-    static int k = cross_info[0]; // number of generations
+    const int k = cross_info[0]; // number of generations
 
-    static double p = (1.0 + (5.0-6.0*rec_frac)*pow(1.0-rec_frac, k-2))/6.0;
+    double p = (1.0 + (5.0-6.0*rec_frac)*pow(1.0-rec_frac, (double)(k-2)))/6.0;
 
     if(gen_left == gen_right)
         return log(p);

--- a/src/cross_dh6.cpp
+++ b/src/cross_dh6.cpp
@@ -1,0 +1,249 @@
+// 6-way doubled haplotypes QTLCross class (for HMM)
+// for maize MAGIC populations developed at the Wisconsin Crop Innovation Center
+
+#include "cross_dh6.h"
+#include <math.h>
+#include <Rcpp.h>
+#include "cross.h"
+#include "cross_util.h"
+#include "cross_do_util.h"
+#include "r_message.h"
+
+enum gen {A=1, H=2, B=3, notA=5, notB=4};
+
+const bool DH6::check_geno(const int gen, const bool is_observed_value,
+                           const bool is_x_chr, const bool is_female,
+                           const IntegerVector& cross_info)
+{
+    // allow any value 0-5 for observed
+    if(is_observed_value) {
+        if(gen==0 || gen==A || gen==H || gen==B ||
+           gen==notA || gen==notB) return true;
+        else return false;
+    }
+
+    const int n_geno = 6;
+
+    if(gen>= 1 && gen <= n_geno) return true;
+
+    return false; // otherwise a problem
+}
+
+const double DH6::init(const int true_gen,
+                       const bool is_x_chr, const bool is_female,
+                       const IntegerVector& cross_info)
+{
+    #ifndef NDEBUG
+    if(!check_geno(true_gen, false, is_x_chr, is_female, cross_info))
+        throw std::range_error("genotype value not allowed");
+    #endif
+
+    return -log(6.0);
+}
+
+const double DH6::emit(const int obs_gen, const int true_gen, const double error_prob,
+                       const IntegerVector& founder_geno, const bool is_x_chr,
+                       const bool is_female, const IntegerVector& cross_info)
+{
+    #ifndef NDEBUG
+    if(!check_geno(true_gen, false, is_x_chr, is_female, cross_info))
+        throw std::range_error("genotype value not allowed");
+    #endif
+
+    if(obs_gen==0) return 0.0; // missing
+
+    int f = founder_geno[true_gen-1]; // founder allele
+    if(f!=1 && f!=3) return 0.0;      // founder missing -> no information
+
+    if(f == obs_gen) return log(1.0 - error_prob);
+
+    return log(error_prob); // genotyping error
+}
+
+
+const double DH6::step(const int gen_left, const int gen_right, const double rec_frac,
+                            const bool is_x_chr, const bool is_female,
+                            const IntegerVector& cross_info)
+{
+    #ifndef NDEBUG
+    if(!check_geno(gen_left, false, is_x_chr, is_female, cross_info) ||
+       !check_geno(gen_right, false, is_x_chr, is_female, cross_info))
+        throw std::range_error("genotype value not allowed");
+    #endif
+
+    static int k = cross_info[0]; // number of generations
+
+    static double p = (1.0 + (5.0-6.0*rec_frac)*pow(1.0-rec_frac, k-2))/6.0;
+
+    if(gen_left == gen_right)
+        return log(p);
+    else
+        return log(1.0-p) - log(5.0);
+}
+
+const IntegerVector DH6::possible_gen(const bool is_x_chr, const bool is_female,
+                                       const IntegerVector& cross_info)
+{
+    int n_geno = 6;
+    IntegerVector result(n_geno);
+
+    for(int i=0; i<n_geno; i++) result[i] = i+1;
+    return result;
+}
+
+const int DH6::ngen(const bool is_x_chr)
+{
+    return 6;
+}
+
+const int DH6::nalleles()
+{
+    return 6;
+}
+
+
+// check that cross_info conforms to expectation
+const bool DH6::check_crossinfo(const IntegerMatrix& cross_info, const bool any_x_chr)
+{
+    bool result = true;
+    const int n_row = cross_info.rows();
+    const int n_col = cross_info.cols();
+    // single column with the number of generations
+
+    if(n_col != 1) {
+        result = false;
+        r_message("cross_info should have 1 column, indicating the number of generations");
+        return result;
+    }
+
+    int n_missing=0;
+    int n_invalid=0;
+    for(int i=0; i<n_row; i++) {
+        if(cross_info(i,0) == NA_INTEGER) ++n_missing;
+        else if(cross_info(i,0) < 2) ++n_invalid;
+    }
+    if(n_missing > 0) {
+        result = false;
+        r_message("cross_info has missing values (it shouldn't)");
+    }
+    if(n_invalid > 0) {
+        result = false;
+        r_message("cross_info has invalid values; number of generations should be >= 2");
+    }
+
+    return result;
+}
+
+
+// check that founder genotype data has correct no. founders and markers
+const bool DH6::check_founder_geno_size(const IntegerMatrix& founder_geno, const int n_markers)
+{
+    bool result=true;
+
+    const int fg_mar = founder_geno.cols();
+    const int fg_f   = founder_geno.rows();
+
+    if(fg_mar != n_markers) {
+        result = false;
+        r_message("founder_geno has incorrect number of markers");
+    }
+
+    if(fg_f != 6) {
+        result = false;
+        r_message("founder_geno should have 6 founders");
+    }
+
+    return result;
+}
+
+// check that founder genotype data has correct values
+const bool DH6::check_founder_geno_values(const IntegerMatrix& founder_geno)
+{
+    const int fg_mar = founder_geno.cols();
+    const int fg_f   = founder_geno.rows();
+
+    for(int f=0; f<fg_f; f++) {
+        for(int mar=0; mar<fg_mar; mar++) {
+            int fg = founder_geno(f,mar);
+            if(fg != 0 && fg != 1 && fg != 3) {
+                // at least one invalid value
+                r_message("founder_geno contains invalid values; should be in {0, 1, 3}");
+                return false;
+            }
+        }
+    }
+
+    return true;
+}
+
+const bool DH6::need_founder_geno()
+{
+    return true;
+}
+
+// geno_names from allele names
+const std::vector<std::string> DH6::geno_names(const std::vector<std::string> alleles,
+                                                const bool is_x_chr)
+{
+    if(alleles.size() < 6)
+        throw std::range_error("alleles must have length 6");
+
+    const int n_alleles = 6;
+
+    std::vector<std::string> result(n_alleles);
+
+    for(int i=0; i<n_alleles; i++)
+        result[i] = alleles[i] + alleles[i];
+
+    return result;
+}
+
+
+const int DH6::nrec(const int gen_left, const int gen_right,
+                         const bool is_x_chr, const bool is_female,
+                         const Rcpp::IntegerVector& cross_info)
+{
+    #ifndef NDEBUG
+    if(!check_geno(gen_left, false, is_x_chr, is_female, cross_info) ||
+       !check_geno(gen_right, false, is_x_chr, is_female, cross_info))
+        throw std::range_error("genotype value not allowed");
+    #endif
+
+    if(gen_left == gen_right) return 0;
+    else return 1;
+}
+
+
+// check whether X chr can be handled
+const bool DH6::check_handle_x_chr(const bool any_x_chr)
+{
+    if(any_x_chr) {
+        r_message("X chr ignored for 6-way doubled haploids.");
+        return false;
+    }
+
+    return true; // most crosses can handle the X chr
+}
+
+// tailored est_map that pre-calculates transition matrices, etc
+const NumericVector DH6::est_map2(const IntegerMatrix& genotypes,
+                                      const IntegerMatrix& founder_geno,
+                                      const bool is_X_chr,
+                                      const LogicalVector& is_female,
+                                      const IntegerMatrix& cross_info,
+                                      const IntegerVector& cross_group,
+                                      const IntegerVector& unique_cross_group,
+                                      const NumericVector& rec_frac,
+                                      const double error_prob,
+                                      const int max_iterations,
+                                      const double tol,
+                                      const bool verbose)
+{
+    Rcpp::stop("est_map not yet implemented for 6-way doubled haploids.");
+
+    // return vector of NAs
+    const int n_rf = rec_frac.size();
+    NumericVector result(n_rf);
+    for(int i=0; i<n_rf; i++) result[i] = NA_REAL;
+    return result ;
+}

--- a/src/cross_dh6.h
+++ b/src/cross_dh6.h
@@ -1,0 +1,66 @@
+// 6-way doubled haplotypes QTLCross class (for HMM)
+// for maize MAGIC populations developed at the Wisconsin Crop Innovation Center
+
+#ifndef CROSS_DH6_H
+#define CROSS_DH6_H
+
+#include <Rcpp.h>
+#include "cross.h"
+
+class DH6 : public QTLCross
+{
+ public:
+    DH6(){
+        crosstype = "dh6";
+        phase_known_crosstype = "dh6";
+    };
+    ~DH6(){};
+
+    const bool check_geno(const int gen, const bool is_observed_value,
+                          const bool is_x_chr, const bool is_female, const Rcpp::IntegerVector& cross_info);
+
+    const double init(const int true_gen,
+                      const bool is_x_chr, const bool is_female, const Rcpp::IntegerVector& cross_info);
+    const double emit(const int obs_gen, const int true_gen, const double error_prob,
+                      const Rcpp::IntegerVector& founder_geno, const bool is_x_chr,
+                      const bool is_female, const Rcpp::IntegerVector& cross_info);
+    const double step(const int gen_left, const int gen_right, const double rec_frac,
+                      const bool is_x_chr, const bool is_female, const Rcpp::IntegerVector& cross_info);
+
+    const Rcpp::IntegerVector possible_gen(const bool is_x_chr, const bool is_female, const Rcpp::IntegerVector& cross_info);
+
+    const int ngen(const bool is_x_chr);
+    const int nalleles();
+
+    const bool check_crossinfo(const Rcpp::IntegerMatrix& cross_info, const bool any_x_chr);
+
+    const bool check_founder_geno_size(const Rcpp::IntegerMatrix& founder_geno, const int n_markers);
+    const bool check_founder_geno_values(const Rcpp::IntegerMatrix& founder_geno);
+    const bool need_founder_geno();
+
+    const std::vector<std::string> geno_names(const std::vector<std::string> alleles, const bool is_x_chr);
+
+    const int nrec(const int gen_left, const int gen_right,
+                   const bool is_x_chr, const bool is_female,
+                   const Rcpp::IntegerVector& cross_info);
+
+    // check whether X chr can be handled
+    const bool check_handle_x_chr(const bool any_x_chr);
+
+    // tailored est_map that pre-calculates transition matrices, etc
+    const Rcpp::NumericVector est_map2(const Rcpp::IntegerMatrix& genotypes,
+                                       const Rcpp::IntegerMatrix& founder_geno,
+                                       const bool is_X_chr,
+                                       const Rcpp::LogicalVector& is_female,
+                                       const Rcpp::IntegerMatrix& cross_info,
+                                       const Rcpp::IntegerVector& cross_group,
+                                       const Rcpp::IntegerVector& unique_cross_group,
+                                       const Rcpp::NumericVector& rec_frac,
+                                       const double error_prob,
+                                       const int max_iterations,
+                                       const double tol,
+                                       const bool verbose);
+
+};
+
+#endif // CROSS_DH6_H

--- a/src/test_hmm.cpp
+++ b/src/test_hmm.cpp
@@ -112,6 +112,18 @@ bool need_founder_geno(const String& crosstype)
     return result;
 }
 
+// [[Rcpp::export]]
+bool check_founder_geno_size(const String& crosstype,
+                             const IntegerMatrix& founder_geno,
+                             const int n_markers)
+{
+    QTLCross* cross = QTLCross::Create(crosstype);
+
+    bool result = cross->check_founder_geno_size(founder_geno, n_markers);
+    delete cross;
+    return result;
+}
+
 // test calculation of vector of emit matrices
 // [[Rcpp::export]]
 std::vector<NumericMatrix> test_emitmatrix(const String& crosstype,

--- a/src/test_hmm.h
+++ b/src/test_hmm.h
@@ -35,6 +35,10 @@ bool test_founder_geno(const Rcpp::String& crosstype, const Rcpp::IntegerMatrix&
 
 bool need_founder_geno(const Rcpp::String& crosstype);
 
+bool check_founder_geno_size(const Rcpp::String& crosstype,
+                             const Rcpp::IntegerMatrix& founder_geno,
+                             const int n_markers);
+
 // test calculation of vector of emit matrices
 std::vector<Rcpp::NumericMatrix> test_emitmatrix(const Rcpp::String& crosstype,
                                                  const double error_prob,

--- a/tests/testthat/test-hmmbasic-ail3.R
+++ b/tests/testthat/test-hmmbasic-ail3.R
@@ -294,3 +294,28 @@ test_that("geno_names works", {
     expect_equal(geno_names("ail3", LETTERS[1:3], FALSE), auto)
     expect_equal(geno_names("ail3", LETTERS[1:3], TRUE), X)
 })
+
+
+
+test_that("nrec works", {
+
+    # autosome genotypes = 1:6
+    expected <- rbind(c(0,1,2,1,2,2),
+                      c(1,0,1,1,1,2),
+                      c(2,1,0,2,1,2),
+                      c(1,1,2,0,1,1),
+                      c(2,1,1,1,0,1),
+                      c(2,2,2,1,1,0))
+    for(i in 1:6)
+        for(j in 1:6) {
+            expect_equal(test_nrec("ail3", i, j, FALSE, FALSE, 0), expected[i,j])
+            expect_equal(test_nrec("ail3", i, j, TRUE, TRUE, 0), expected[i,j])
+        }
+
+    # X chromosome male
+    expected <- matrix(1, ncol=3, nrow=3) - diag(rep(1,3))
+    for(i in 1:3)
+        for(j in 1:3)
+            expect_equal(test_nrec("ail3", i+6, j+6, TRUE, FALSE, 0), expected[i,j])
+
+})

--- a/tests/testthat/test-hmmbasic-ail3.R
+++ b/tests/testthat/test-hmmbasic-ail3.R
@@ -1,0 +1,296 @@
+context("basic HMM functions in 3-way AIL")
+
+test_that("AIL3 nalleles works", {
+    expect_equal(nalleles("ail3"), 3)
+})
+
+test_that("AIL3 check_geno works", {
+
+    # observed genotypes
+    for(i in 0:5) {
+        # Autosome
+        expect_true(test_check_geno("ail3", i, TRUE, FALSE, FALSE, 20))
+        # Female X
+        expect_true(test_check_geno("ail3", i, TRUE, TRUE, TRUE, 20))
+        # Male X
+        expect_true(test_check_geno("ail3", i, TRUE, TRUE, FALSE, 20))
+    }
+    for(i in c(-1, 6)) {
+        # Autosome
+        expect_false(test_check_geno("ail3", i, TRUE, FALSE, FALSE, 20))
+        # Female X
+        expect_false(test_check_geno("ail3", i, TRUE, TRUE, TRUE, 20))
+        # Male X
+        expect_false(test_check_geno("ail3", i, TRUE, TRUE, FALSE, 20))
+    }
+
+    # true genotypes, autosome and female X
+    for(i in 1:6) {
+        # Autosome
+        expect_true(test_check_geno("ail3", i, FALSE, FALSE, FALSE, 20))
+        # Female X
+        expect_true(test_check_geno("ail3", i, FALSE, TRUE, TRUE, 20))
+    }
+    for(i in c(0, 7)) {
+        # Autosome
+        expect_false(test_check_geno("ail3", i, FALSE, FALSE, FALSE, 20))
+        # Female X
+        expect_false(test_check_geno("ail3", i, FALSE, TRUE, TRUE, 20))
+    }
+
+    # true genotypes, autosome and female X
+    for(i in 6 + 1:3) {
+        expect_true(test_check_geno("ail3", i, FALSE, TRUE, FALSE, 20))
+    }
+    for(i in c(0:6, 6+4)) {
+        expect_false(test_check_geno("ail3", i, FALSE, TRUE, FALSE, 20))
+    }
+
+})
+
+test_that("AIL3 n_gen works", {
+
+    expect_equal(test_ngen("ail3", FALSE), 6)
+    expect_equal(test_ngen("ail3", TRUE),  9)
+
+})
+
+test_that("AIL3 possible_gen works", {
+
+    # autosome
+    expect_equal(test_possible_gen("ail3", FALSE, FALSE, 20), 1:6)
+
+    # X female
+    expect_equal(test_possible_gen("ail3", TRUE, TRUE, 20), 1:6)
+
+    # X male
+    expect_equal(test_possible_gen("ail3", TRUE, FALSE, 20), 6+(1:3))
+
+})
+
+test_that("AIL3 init works", {
+
+    hom <- cumsum(1:3)
+    het <- (1:6)[!((1:6) %in% cumsum(1:3))]
+    male <- 6 + (1:3)
+
+    for(i in hom) {
+        # autosome and female X
+        expect_equal(test_init("ail3", i, FALSE, FALSE, 20), log(1/9))
+        expect_equal(test_init("ail3", i, TRUE,  TRUE,  20), log(1/9))
+    }
+
+    for(i in het) {
+        # autosome and female X
+        expect_equal(test_init("ail3", i, FALSE, FALSE, 20), log(2/9))
+        expect_equal(test_init("ail3", i, TRUE,  TRUE,  20), log(2/9))
+    }
+
+    for(i in male)
+        expect_equal(test_init("ail3", i, TRUE,  FALSE, 20), log(1/3))
+
+})
+
+
+test_that("AIL3 emit works", {
+
+    fgen <- c(1,3,0) # founder genotypes; 0=missing, 1=AA, 3=BB
+    err <- 0.01
+
+    # Autosome or female X
+    # truth = homA: AA (1)
+    expected <- log(c(1-err, err/2, err/2, 1-err/2, err))
+    for(trueg in 1) {
+        for(obsg in 1:5) {
+            expect_equal(test_emit("ail3", obsg, trueg, err, fgen, FALSE, FALSE, 20), expected[obsg])
+            expect_equal(test_emit("ail3", obsg, trueg, err, fgen,  TRUE,  TRUE, 20), expected[obsg])
+        }
+    }
+    # truth = het: AB (2)
+    expected <- log(c(err/2, 1-err, err/2, 1-err/2, 1-err/2))
+    for(trueg in 2) {
+        for(obsg in 1:5) {
+            expect_equal(test_emit("ail3", obsg, trueg, err, fgen, FALSE, FALSE, 20), expected[obsg])
+            expect_equal(test_emit("ail3", obsg, trueg, err, fgen,  TRUE,  TRUE, 20), expected[obsg])
+        }
+    }
+    # truth = homB: BB (3)
+    expected <- log(c(err/2, err/2, 1-err, err, 1-err/2))
+    for(trueg in 3) {
+        for(obsg in 1:5) {
+            expect_equal(test_emit("ail3", obsg, trueg, err, fgen, FALSE, FALSE, 20), expected[obsg])
+            expect_equal(test_emit("ail3", obsg, trueg, err, fgen,  TRUE,  TRUE, 20), expected[obsg])
+        }
+    }
+    # truth = A-: AC (4)
+    expected <- log(c(1-err,1,err,1-err,err))
+    for(trueg in 4) {
+        for(obsg in 1:5) {
+            expect_equal(test_emit("ail3", obsg, trueg, err, fgen, FALSE, FALSE, 20), expected[obsg])
+            expect_equal(test_emit("ail3", obsg, trueg, err, fgen,  TRUE,  TRUE, 20), expected[obsg])
+        }
+    }
+    # truth = B-: BC (5)
+    expected <- log(c(err,1,1-err,err,1-err))
+    for(trueg in 5) {
+        for(obsg in 1:5) {
+            expect_equal(test_emit("ail3", obsg, trueg, err, fgen, FALSE, FALSE, 20), expected[obsg])
+            expect_equal(test_emit("ail3", obsg, trueg, err, fgen,  TRUE,  TRUE, 20), expected[obsg])
+        }
+    }
+
+    # male X: treat het as missing
+    # truth = hemA: A (1+6)
+    expected <- log(c(1-err, 1, err, 1-err, err))
+    for(trueg in 7)
+        for(obsg in 1:5)
+            expect_equal(test_emit("ail3", obsg, trueg, err, fgen,  TRUE, FALSE, 20), expected[obsg])
+    # truth = hemB: BB (2+6)
+    expected <- log(c(err, 1, 1-err, err, 1-err))
+    for(trueg in 8)
+        for(obsg in 1:5)
+            expect_equal(test_emit("ail3", obsg, trueg, err, fgen,  TRUE, FALSE, 20), expected[obsg])
+    # truth = missing: C (3+6)
+    expected <- rep(0,5)
+    for(trueg in 9)
+        for(obsg in 1:5)
+            expect_equal(test_emit("ail3", obsg, trueg, err, fgen,  TRUE, FALSE, 20), expected[obsg])
+
+})
+
+test_that("AIL3 step works for autosome", {
+
+    pAA <- function(n, r, k=3)
+    {
+        stopifnot(n >= 2)
+        (1 - (1 - k + k*r)*(1-r)^(n-2))/k^2
+    }
+
+    rf <- 0.02
+    ngen <- 10
+
+    pAA <- pAA(ngen, rf)
+    R <- (1 - 3*pAA)
+
+    # expected values
+    expected <- matrix(ncol=6, nrow=6)
+    # AA->AA
+    expected[1,1] <- expected[3,3] <- expected[6,6] <- (1-R)^2
+    # AB->AB
+    expected[2,2] <- expected[4,4] <- expected[5,5] <- (1-R)^2 + (R/2)^2
+    # AA->BB
+    expected[1,3] <- expected[1,6] <- expected[3,6] <- (R/2)^2
+    # AA->AB
+    expected[1,2] <- expected[1,4] <- expected[3,5] <- expected[2,3] <-
+        expected[4,6] <- expected[5,6] <- (1-R)*(R/2)
+    # AA->BC
+    expected[1,5] <- expected[3,4] <- expected[2,6] <- (R/2)^2
+    # AB->AC
+    expected[2,4] <- expected[2,5] <- expected[4,5] <- (1-R)*(R/2) + (R/2)^2
+    expected[lower.tri(expected)] <- t(expected)[lower.tri(expected)]
+    expected <- log(expected)
+
+    result <- matrix(ncol=6, nrow=6)
+    for(i in 1:6)
+        for(j in 1:6)
+            result[i,j] <- test_step("ail3", i, j, rf, FALSE, FALSE, ngen)
+
+    expect_equal(result, expected)
+
+})
+
+
+test_that("AIL3 step works for X chromosome", {
+
+    pAA <- function(n, r, k=3)
+    {
+        stopifnot(n >= 2)
+        z <- sqrt((1-r)*(9-r))
+
+        male <- (1-r)/k * ( (1-r+z)/(2*z) * ((1-r-z)/4)^(n-2) +
+                            (-1+r+z)/(2*z) * ((1-r+z)/4)^(n-2)) +
+            (2-r)/(2*k) * ( (1-r-z)/2 * (1-r+z)/(2*z) * ((1-r-z)/4)^(n-2) +
+                            (1-r+z)/2 * (-1+r+z)/(2*z) * ((1-r+z)/4)^(n-2)) +
+            ( (r^2 + r*(z-5))/(k^2*(3+r+z)) * (1-r+z)/(2*z) * ((1-r-z)/4)^(n-2) +
+              (r^2 - r*(z+5))/(k^2*(3+r-z)) * (-1+r+z)/(2*z) * ((1-r+z)/4)^(n-2) + 1/k^2)
+
+        female <- (1-r)/k * ( (-1/z)*((1-r-z)/4)^(n-2) +
+                              (1/z)*((1-r+z)/4)^(n-2)) +
+            (2-r)/(2*k) * ( (1-r-z)/2 * (-1/z)*((1-r-z)/4)^(n-2) +
+                            (1-r+z)/2 *  (1/z)*((1-r+z)/4)^(n-2)) +
+            ( (r^2 + r*(z-5))/(k^2*(3+r+z)) * (-1/z)*((1-r-z)/4)^(n-2) +
+              (r^2 - r*(z+5))/(k^2*(3+r-z)) * (1/z)*((1-r+z)/4)^(n-2)  + 1/k^2)
+
+        if(any(r==0))
+            male[r==0] <- female[r==0] <- 1/k
+
+        if(any(r==1)) {
+            if(n==2) male[r==1] <- 0
+            if(n>2) male[r==1] <- 1/k^2
+            if(n==2) female[r==1] <- 1/(2*k)
+            if(n==3) female[r==1] <- 1/(2*k^2)
+            if(n>3)  female[r==1] <- 1/k^2
+        }
+
+        list(female=female, male=male)
+    }
+
+    rf <- 0.02
+    ngen <- 10
+
+    pAA <- pAA(ngen, rf)
+
+    # female X
+    R <- (1 - 3*pAA$female)
+
+    # expected values
+    expected <- matrix(ncol=6, nrow=6)
+    # AA->AA
+    expected[1,1] <- expected[3,3] <- expected[6,6] <- (1-R)^2
+    # AB->AB
+    expected[2,2] <- expected[4,4] <- expected[5,5] <- (1-R)^2 + (R/2)^2
+    # AA->BB
+    expected[1,3] <- expected[1,6] <- expected[3,6] <- (R/2)^2
+    # AA->AB
+    expected[1,2] <- expected[1,4] <- expected[3,5] <- expected[2,3] <-
+        expected[4,6] <- expected[5,6] <- (1-R)*(R/2)
+    # AA->BC
+    expected[1,5] <- expected[3,4] <- expected[2,6] <- (R/2)^2
+    # AB->AC
+    expected[2,4] <- expected[2,5] <- expected[4,5] <- (1-R)*(R/2) + (R/2)^2
+    expected[lower.tri(expected)] <- t(expected)[lower.tri(expected)]
+    expected <- log(expected)
+
+    result <- matrix(ncol=6, nrow=6)
+    for(i in 1:6)
+        for(j in 1:6)
+            result[i,j] <- test_step("ail3", i, j, rf, TRUE, TRUE, ngen)
+
+    expect_equal(result, expected)
+
+    # male X
+    R <- (1 - 3*pAA$male)
+
+    # expected values
+    expected <- matrix(R/2, ncol=3, nrow=3)
+    diag(expected) <- 1-R
+    expected <- log(expected)
+
+    result <- matrix(ncol=3, nrow=3)
+    for(i in 1:3)
+        for(j in 1:3)
+            result[i,j] <- test_step("ail3", 6+i, 6+j, rf, TRUE, FALSE, ngen)
+
+    expect_equal(result, expected)
+
+})
+
+
+
+test_that("geno_names works", {
+    auto <- c("AA", "AB", "BB", "AC", "BC", "CC")
+    X <- c(auto, paste0(LETTERS[1:3], "Y"))
+
+    expect_equal(geno_names("ail3", LETTERS[1:3], FALSE), auto)
+    expect_equal(geno_names("ail3", LETTERS[1:3], TRUE), X)
+})

--- a/tests/testthat/test-hmmbasic-ail3pk.R
+++ b/tests/testthat/test-hmmbasic-ail3pk.R
@@ -1,0 +1,266 @@
+context("basic HMM functions in phase-known 3-way AIL")
+
+test_that("AIL3PK nalleles works", {
+    expect_equal(nalleles("ail3pk"), 3)
+})
+
+test_that("AIL3PK check_geno works", {
+
+    # observed genotypes
+    for(i in 0:5) {
+        # Autosome
+        expect_true(test_check_geno("ail3pk", i, TRUE, FALSE, FALSE, 20))
+        # Female X
+        expect_true(test_check_geno("ail3pk", i, TRUE, TRUE, TRUE, 20))
+        # Male X
+        expect_true(test_check_geno("ail3pk", i, TRUE, TRUE, FALSE, 20))
+    }
+    for(i in c(-1, 6)) {
+        # Autosome
+        expect_false(test_check_geno("ail3pk", i, TRUE, FALSE, FALSE, 20))
+        # Female X
+        expect_false(test_check_geno("ail3pk", i, TRUE, TRUE, TRUE, 20))
+        # Male X
+        expect_false(test_check_geno("ail3pk", i, TRUE, TRUE, FALSE, 20))
+    }
+
+    # true genotypes, autosome and female X
+    for(i in 1:9) {
+        # Autosome
+        expect_true(test_check_geno("ail3pk", i, FALSE, FALSE, FALSE, 20))
+        # Female X
+        expect_true(test_check_geno("ail3pk", i, FALSE, TRUE, TRUE, 20))
+    }
+    for(i in c(0, 10)) {
+        # Autosome
+        expect_false(test_check_geno("ail3pk", i, FALSE, FALSE, FALSE, 20))
+        # Female X
+        expect_false(test_check_geno("ail3pk", i, FALSE, TRUE, TRUE, 20))
+    }
+
+    # true genotypes, autosome and female X
+    for(i in 9 + 1:3) {
+        expect_true(test_check_geno("ail3pk", i, FALSE, TRUE, FALSE, 20))
+    }
+    for(i in c(0:9, 9+4)) {
+        expect_false(test_check_geno("ail3pk", i, FALSE, TRUE, FALSE, 20))
+    }
+
+})
+
+test_that("AIL3PK n_gen works", {
+
+    expect_equal(test_ngen("ail3pk", FALSE), 9)
+    expect_equal(test_ngen("ail3pk", TRUE),  12)
+
+})
+
+test_that("AIL3PK possible_gen works", {
+
+    # autosome
+    expect_equal(test_possible_gen("ail3pk", FALSE, FALSE, 20), 1:9)
+
+    # X female
+    expect_equal(test_possible_gen("ail3pk", TRUE, TRUE, 20), 1:9)
+
+    # X male
+    expect_equal(test_possible_gen("ail3pk", TRUE, FALSE, 20), 9+(1:3))
+
+})
+
+test_that("AIL3PK init works", {
+
+    for(i in 1:9) {
+        # autosome and female X
+        expect_equal(test_init("ail3pk", i, FALSE, FALSE, 20), log(1/9))
+        expect_equal(test_init("ail3pk", i, TRUE,  TRUE,  20), log(1/9))
+    }
+
+    for(i in 10:12)
+        expect_equal(test_init("ail3pk", i, TRUE,  FALSE, 20), log(1/3))
+
+})
+
+
+test_that("AIL3PK emit works", {
+
+    fgen <- c(1,3,0) # founder genotypes; 0=missing, 1=AA, 3=BB
+    err <- 0.01
+
+    # Autosome or female X
+    # truth = homA: AA (1)
+    expected <- log(c(1-err, err/2, err/2, 1-err/2, err))
+    for(trueg in 1) {
+        for(obsg in 1:5) {
+            expect_equal(test_emit("ail3pk", obsg, trueg, err, fgen, FALSE, FALSE, 20), expected[obsg])
+            expect_equal(test_emit("ail3pk", obsg, trueg, err, fgen,  TRUE,  TRUE, 20), expected[obsg])
+        }
+    }
+    # truth = het: AB (2) or BA (7)
+    expected <- log(c(err/2, 1-err, err/2, 1-err/2, 1-err/2))
+    for(trueg in c(2,7)) {
+        for(obsg in 1:5) {
+            expect_equal(test_emit("ail3pk", obsg, trueg, err, fgen, FALSE, FALSE, 20), expected[obsg])
+            expect_equal(test_emit("ail3pk", obsg, trueg, err, fgen,  TRUE,  TRUE, 20), expected[obsg])
+        }
+    }
+    # truth = homB: BB (3)
+    expected <- log(c(err/2, err/2, 1-err, err, 1-err/2))
+    for(trueg in 3) {
+        for(obsg in 1:5) {
+            expect_equal(test_emit("ail3pk", obsg, trueg, err, fgen, FALSE, FALSE, 20), expected[obsg])
+            expect_equal(test_emit("ail3pk", obsg, trueg, err, fgen,  TRUE,  TRUE, 20), expected[obsg])
+        }
+    }
+    # truth = A-: AC (4) or CA (8)
+    expected <- log(c(1-err,1,err,1-err,err))
+    for(trueg in c(4,8)) {
+        for(obsg in 1:5) {
+            expect_equal(test_emit("ail3pk", obsg, trueg, err, fgen, FALSE, FALSE, 20), expected[obsg])
+            expect_equal(test_emit("ail3pk", obsg, trueg, err, fgen,  TRUE,  TRUE, 20), expected[obsg])
+        }
+    }
+    # truth = B-: BC (5) or CB (9)
+    expected <- log(c(err,1,1-err,err,1-err))
+    for(trueg in c(5,9)) {
+        for(obsg in 1:5) {
+            expect_equal(test_emit("ail3pk", obsg, trueg, err, fgen, FALSE, FALSE, 20), expected[obsg])
+            expect_equal(test_emit("ail3pk", obsg, trueg, err, fgen,  TRUE,  TRUE, 20), expected[obsg])
+        }
+    }
+
+    # male X: treat het as missing
+    # truth = hemA: A (1+9)
+    expected <- log(c(1-err, 1, err, 1-err, err))
+    for(trueg in 10)
+        for(obsg in 1:5)
+            expect_equal(test_emit("ail3pk", obsg, trueg, err, fgen,  TRUE, FALSE, 20), expected[obsg])
+    # truth = hemB: BB (2+9)
+    expected <- log(c(err, 1, 1-err, err, 1-err))
+    for(trueg in 11)
+        for(obsg in 1:5)
+            expect_equal(test_emit("ail3pk", obsg, trueg, err, fgen,  TRUE, FALSE, 20), expected[obsg])
+    # truth = missing: C (3+9)
+    expected <- rep(0,5)
+    for(trueg in 12)
+        for(obsg in 1:5)
+            expect_equal(test_emit("ail3pk", obsg, trueg, err, fgen,  TRUE, FALSE, 20), expected[obsg])
+
+})
+
+test_that("AIL3PK step works for autosome", {
+
+    pAA <- function(n, r, k=3)
+    {
+        stopifnot(n >= 2)
+        (1 - (1 - k + k*r)*(1-r)^(n-2))/k^2
+    }
+
+    rf <- 0.02
+    ngen <- 10
+
+    pAA <- pAA(ngen, rf)
+    R <- (1 - 3*pAA)
+
+    # expected values
+    expected <- matrix(1, ncol=9, nrow=9)
+    a1 <- c("A", "A", "B", "A", "B", "C", "B", "C", "C")
+    a2 <- c("A", "B", "B", "C", "C", "C", "A", "A", "B")
+
+    for(i in 1:9) {
+        for(j in 1:9) {
+            expected[i,j] <- expected[i,j] * ifelse(a1[i]==a1[j], 1-R, R/2)
+            expected[i,j] <- expected[i,j] * ifelse(a2[i]==a2[j], 1-R, R/2)
+        }
+    }
+    expected <- log(expected)
+
+    result <- matrix(ncol=9, nrow=9)
+    for(i in 1:9)
+        for(j in 1:9)
+            result[i,j] <- test_step("ail3pk", i, j, rf, FALSE, FALSE, ngen)
+
+    expect_equal(result, expected)
+
+})
+
+
+test_that("AIL3PK step works for X chromosome", {
+
+    pAA <- function(n, r, k=3)
+    {
+        stopifnot(n >= 2)
+        z <- sqrt((1-r)*(9-r))
+
+        male <- (1-r)/k * ( (1-r+z)/(2*z) * ((1-r-z)/4)^(n-2) +
+                            (-1+r+z)/(2*z) * ((1-r+z)/4)^(n-2)) +
+            (2-r)/(2*k) * ( (1-r-z)/2 * (1-r+z)/(2*z) * ((1-r-z)/4)^(n-2) +
+                            (1-r+z)/2 * (-1+r+z)/(2*z) * ((1-r+z)/4)^(n-2)) +
+            ( (r^2 + r*(z-5))/(k^2*(3+r+z)) * (1-r+z)/(2*z) * ((1-r-z)/4)^(n-2) +
+              (r^2 - r*(z+5))/(k^2*(3+r-z)) * (-1+r+z)/(2*z) * ((1-r+z)/4)^(n-2) + 1/k^2)
+
+        female <- (1-r)/k * ( (-1/z)*((1-r-z)/4)^(n-2) +
+                              (1/z)*((1-r+z)/4)^(n-2)) +
+            (2-r)/(2*k) * ( (1-r-z)/2 * (-1/z)*((1-r-z)/4)^(n-2) +
+                            (1-r+z)/2 *  (1/z)*((1-r+z)/4)^(n-2)) +
+            ( (r^2 + r*(z-5))/(k^2*(3+r+z)) * (-1/z)*((1-r-z)/4)^(n-2) +
+              (r^2 - r*(z+5))/(k^2*(3+r-z)) * (1/z)*((1-r+z)/4)^(n-2)  + 1/k^2)
+
+        if(any(r==0))
+            male[r==0] <- female[r==0] <- 1/k
+
+        if(any(r==1)) {
+            if(n==2) male[r==1] <- 0
+            if(n>2) male[r==1] <- 1/k^2
+            if(n==2) female[r==1] <- 1/(2*k)
+            if(n==3) female[r==1] <- 1/(2*k^2)
+            if(n>3)  female[r==1] <- 1/k^2
+        }
+
+        list(female=female, male=male)
+    }
+
+    rf <- 0.02
+    ngen <- 10
+
+    pAA <- pAA(ngen, rf)
+
+    # female X
+    R <- (1 - 3*pAA$female)
+
+    # expected values
+    expected <- matrix(1, ncol=9, nrow=9)
+    a1 <- c("A", "A", "B", "A", "B", "C", "B", "C", "C")
+    a2 <- c("A", "B", "B", "C", "C", "C", "A", "A", "B")
+
+    for(i in 1:9) {
+        for(j in 1:9) {
+            expected[i,j] <- expected[i,j] * ifelse(a1[i]==a1[j], 1-R, R/2)
+            expected[i,j] <- expected[i,j] * ifelse(a2[i]==a2[j], 1-R, R/2)
+        }
+    }
+    expected <- log(expected)
+
+    result <- matrix(ncol=9, nrow=9)
+    for(i in 1:9)
+        for(j in 1:9)
+            result[i,j] <- test_step("ail3pk", i, j, rf, TRUE, TRUE, ngen)
+
+    expect_equal(result, expected)
+
+    # male X
+    R <- (1 - 3*pAA$male)
+
+    # expected values
+    expected <- matrix(R/2, ncol=3, nrow=3)
+    diag(expected) <- 1-R
+    expected <- log(expected)
+
+    result <- matrix(ncol=3, nrow=3)
+    for(i in 1:3)
+        for(j in 1:3)
+            result[i,j] <- test_step("ail3pk", 9+i, 9+j, rf, TRUE, FALSE, ngen)
+
+    expect_equal(result, expected)
+
+})

--- a/tests/testthat/test-hmmbasic-dh6.R
+++ b/tests/testthat/test-hmmbasic-dh6.R
@@ -1,0 +1,68 @@
+context("basic HMM functions in 6-way doubled haploids")
+
+test_that("dh6 n_gen, n_alleles work", {
+
+    expect_equal(nalleles("dh6"), 6)
+
+    expect_equal(test_ngen("dh6", FALSE), 6)
+
+})
+
+test_that("dh6 possible_gen work", {
+
+    expect_equal(test_possible_gen("dh6", FALSE, FALSE, 1:6), 1:6)
+
+})
+
+# FIX_ME: test check_geno
+
+test_that("dh6 init work", {
+
+    expect_equal( sapply(1:6, function(i) test_init("dh6", i, FALSE, FALSE, 1:6)), log(rep(1/6, 6)) )
+
+})
+
+# FIX_ME: test emit
+
+test_that("dh6 step works", {
+
+    for(rf in c(0.01, 0.1, 0.45)) {
+        for(ngen in c(3, 5)) {
+            expected <- matrix((5 - (5-6*rf)*(1-rf)^(ngen-2))/30, ncol=6, nrow=6)
+            diag(expected) <- (1 + (5-6*rf)*(1-rf)^(ngen-2))/6
+
+            result <- matrix(ncol=6, nrow=6)
+            for(i in 1:6) {
+                for(j in 1:6) {
+                    result[i,j] <- test_step("dh6", i, j, rf, FALSE, FALSE, ngen)
+                }
+            }
+
+            expect_equal(result, log(expected))
+        }
+    }
+
+})
+
+
+test_that("dh6 geno_names work", {
+
+    expect_equal( geno_names("dh6", LETTERS[5:10], FALSE), paste0(LETTERS[5:10], LETTERS[5:10]) )
+
+})
+
+test_that("dh6 nrec work", {
+
+    x <- matrix(ncol=6, nrow=6)
+    x <- matrix(as.numeric(col(x) != row(x)), ncol=6)
+
+    res6 <- matrix(ncol=6, nrow=6)
+    for(i in 1:6) {
+        for(j in 1:6) {
+            res6[i,j] <- test_nrec("dh6", i, j, FALSE, FALSE, 3)
+        }
+    }
+
+    expect_equal( res6, x )
+
+})


### PR DESCRIPTION
- Add cross type `"dh6"` (6-way doubled haploids, for a set of maize MAGIC lines)
- Add cross type `"ail3"` (3-way advanced intercross lines)
- Add checks of dims of founder genotypes in `check_cross2()`