### PR TITLE
Small corrections for AIL and MAGIC19

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: qtl2geno
-Version: 0.5-33
-Date: 2017-10-04
+Version: 0.5-34
+Date: 2017-10-26
 Title: Treatment of Marker Genotypes for QTL Experiments
 Description: Functions to calculate QTL genotype probabilities, impute
     QTL genotypes, and estimate genetic maps. Part of R/qtl2, a

--- a/src/cross_ail.cpp
+++ b/src/cross_ail.cpp
@@ -40,7 +40,13 @@ const double AIL::init(const int true_gen,
     #endif
 
     const int n_gen = cross_info[0];
-    const int dir   = cross_info[1];
+    int dir;
+    if(cross_info.size() > 1) {
+       dir = cross_info[1];
+    }
+    else { // assume balanced case
+        dir = 2;
+    }
 
     if(is_x_chr) {
         if(dir==2) { // balanced case
@@ -151,7 +157,13 @@ const double AIL::step(const int gen_left, const int gen_right, const double rec
     #endif
 
     const int n_gen = cross_info[0];
-    const int dir = cross_info[1];
+    int dir;
+    if(cross_info.size() > 1) {
+       dir = cross_info[1];
+    }
+    else { // assume balanced case
+        dir = 2;
+    }
 
     if(is_x_chr) {
         if(dir == 2) { // balanced case

--- a/src/cross_magic19.cpp
+++ b/src/cross_magic19.cpp
@@ -185,11 +185,6 @@ const int MAGIC19::nrec(const int gen_left, const int gen_right,
 const double MAGIC19::est_rec_frac(const Rcpp::NumericVector& gamma, const bool is_x_chr,
                                    const Rcpp::IntegerMatrix& cross_info, const int n_gen)
 {
-    #ifndef RQTL2_NODEBUG
-    if(cross_info.rows() != 19) // incorrect number of founders
-        throw std::range_error("cross_info should contain 19 founders");
-    #endif
-
     double R = QTLCross::est_rec_frac(gamma, is_x_chr, cross_info, n_gen);
 
     // inverse of R = (90-54r+18r^2)/19/(1+2r)


### PR DESCRIPTION
- For AILs, deal with the case that there's just one `cross_info` column
- For MAGIC19, remove some debug code that tries to deal with `cross_info`, which isn't necessary for this cross type.